### PR TITLE
Change .impl extension to the actually correct .so extension for modules on OS X. Lets audacious start up and play some simple stream.

### DIFF
--- a/m4/buildsys.m4
+++ b/m4/buildsys.m4
@@ -100,7 +100,7 @@ AC_DEFUN([BUILDSYS_SHARED_LIB], [
 			LDFLAGS_RPATH='-Wl,-rpath,${libdir}'
 			PLUGIN_CFLAGS='-fPIC -DPIC -mmacosx-version-min=10.5'
 			PLUGIN_LDFLAGS='-mmacosx-version-min=10.5 -bundle -undefined dynamic_lookup'
-			PLUGIN_SUFFIX='.impl'
+			PLUGIN_SUFFIX='.so'
 			INSTALL_LIB='&& ${INSTALL} -m 755 $$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib && ${LN_S} -f $${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib ${DESTDIR}${libdir}/$$i'
 			UNINSTALL_LIB='&& rm -f ${DESTDIR}${libdir}/$$i ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.dylib ${DESTDIR}${libdir}/$${i%.dylib}.${LIB_MAJOR}.${LIB_MINOR}.dylib'
 			CLEAN_LIB=''


### PR DESCRIPTION
Copypasta: Dynamically linked loadable modules are have the ".so" suffix
on Darwin, too. This is not to be confused with dynamically linked
loadable _libraries_, which have the ".dylib" suffix on Mac OS X/Darwin.
As Audacious uses dyn. MODULES, we should use the ".so" extension (which
is also defined by glib-2.0 for dyn. modules.)
