### PR TITLE
Scroll to end of playlist

### DIFF
--- a/src/libaudgui/list.c
+++ b/src/libaudgui/list.c
@@ -382,6 +382,18 @@ static void stop_autoscroll (ListModel * model)
     model->scroll_speed = 0;
 }
 
+EXPORT void list_scroll_to_end(GtkWidget *widget, int count)
+{
+    GtkAdjustment * adj = gtk_scrollable_get_vadjustment ((GtkScrollable *) widget);
+    if (! adj)
+        return;
+
+    gtk_adjustment_set_upper(adj, gtk_adjustment_get_upper(adj) + 100 * count);
+    gtk_adjustment_changed(adj);
+    int new = gtk_adjustment_get_upper (adj) - gtk_adjustment_get_page_size(adj);
+    gtk_adjustment_set_value (adj, new);
+}
+
 static bool_t autoscroll (GtkWidget * widget)
 {
     ListModel * model = (ListModel *) gtk_tree_view_get_model

--- a/src/libaudgui/list.h
+++ b/src/libaudgui/list.h
@@ -76,4 +76,7 @@ void audgui_list_set_focus (GtkWidget * list, int row);
 int audgui_list_row_at_point (GtkWidget * list, int x, int y);
 int audgui_list_row_at_point_rounded (GtkWidget * list, int x, int y);
 
+/* Scrolls to end of list. Count is number of entries added. */
+void list_scroll_to_end(GtkWidget *widget, int count);
+
 #endif


### PR DESCRIPTION
When adding a new file through "File->Add file" scroll to end of playlist.

Fixes #180. (redmine.audacious-media-player.org/issues/180)
