### PR TITLE
gtkui: scroll to end of list

### DIFF
--- a/src/libaudgui/list.c
+++ b/src/libaudgui/list.c
@@ -382,6 +382,13 @@ static void stop_autoscroll (ListModel * model)
     model->scroll_speed = 0;
 }
 
+EXPORT void audgui_list_scroll_to_end(GtkWidget *widget)
+{
+    GtkTreePath * p = gtk_tree_path_new_from_indices(audgui_list_row_count(widget) - 1, -1);
+    gtk_tree_view_scroll_to_cell((GtkTreeView *) widget, p, NULL, FALSE, 0, 0);
+    gtk_tree_path_free(p);
+}
+
 static bool_t autoscroll (GtkWidget * widget)
 {
     ListModel * model = (ListModel *) gtk_tree_view_get_model

--- a/src/libaudgui/list.h
+++ b/src/libaudgui/list.h
@@ -76,4 +76,7 @@ void audgui_list_set_focus (GtkWidget * list, int row);
 int audgui_list_row_at_point (GtkWidget * list, int x, int y);
 int audgui_list_row_at_point_rounded (GtkWidget * list, int x, int y);
 
+/* Scrolls to end of list. Count is number of entries added. */
+void audgui_list_scroll_to_end(GtkWidget *widget);
+
 #endif


### PR DESCRIPTION
When adding a new file through "File->Add file" scroll to end of playlist.

Fixes #180. (redmine.audacious-media-player.org/issues/180)
