### PR TITLE
"Stop After This Song" should advance the playlist before stopping

### DIFF
--- a/src/audacious/playback.c
+++ b/src/audacious/playback.c
@@ -310,20 +310,18 @@ static bool_t end_cb (void * unused)
         failed_entries = 0;
 
     int playlist = playlist_get_playing ();
-
-    if (get_bool (NULL, "stop_after_current_song"))
-        goto STOP;
+    bool_t stop = get_bool (NULL, "stop_after_current_song");
 
     if (repeat_a >= 0 || repeat_b >= 0)
     {
-        if (failed_entries)
+        if (stop || failed_entries)
             goto STOP;
 
         playback_play (MAX (repeat_a, 0), FALSE);
     }
     else if (get_bool (NULL, "no_playlist_advance"))
     {
-        if (failed_entries || ! get_bool (NULL, "repeat"))
+        if (stop || failed_entries || ! get_bool (NULL, "repeat"))
             goto STOP;
 
         playback_play (0, FALSE);
@@ -338,6 +336,8 @@ static bool_t end_cb (void * unused)
             playlist_set_position (playlist, -1);
             hook_call ("playlist end reached", NULL);
         }
+        else if (stop)
+            goto STOP;
     }
 
     return FALSE;


### PR DESCRIPTION
After commit 63df21d3751f25804037f56c576a14b81d0e1eb7 the playlist was
no longer advanced when the stop after this song option was chosen.
This restores the old behaviour and advances the playlist before
stopping (unless "No Playlist Advance" was also chosen or a repeat was
active).
