### PR TITLE
Fix one compile error when configuring for debug build (`-O0 -g3`)

### DIFF
--- a/src/libaudcore/audstrings.c
+++ b/src/libaudcore/audstrings.c
@@ -25,6 +25,7 @@
 #include <glib.h>
 #include <string.h>
 #include <ctype.h>
+#include <locale.h>
 
 #include <audacious/i18n.h>
 


### PR DESCRIPTION
When doing a debug compile using the below commands the build fails:

```
make clean
./configure CFLAGS='-g3 -O0'
make
```

The error output is

```
audstrings.c: In function ‘filename_to_uri’:
audstrings.c:147:9: warning: implicit declaration of function ‘setlocale’
[-Wimplicit-function-declaration]
audstrings.c:147:42: error: ‘LC_ALL’ undeclared (first use in this function)
audstrings.c:147:42: note: each undeclared identifier is reported only once for
each function it appears in
audstrings.c: In function ‘uri_to_filename’:
audstrings.c:189:42: error: ‘LC_ALL’ undeclared (first use in this function)
Failed to compile audstrings.c (lib)!
make[5]: *** [audstrings.lib.o] Error 1
make[4]: *** [all] Error 2
make[3]: *** [subdirs] Error 2
make[2]: *** [all] Error 2
make[1]: *** [subdirs] Error 2
make: *** [all] Error 2
```

There's no difference in output between `./configure` and `./configure
CFLAGS='-g3 -O0'`. Neither is there one between the resulting files in the
directory. Seems to be a library problem somewhere or this simple fix.

Tested on Fedora 18.
