### PR TITLE
Focus on the current song when initializing "Jump to Song".

### DIFF
--- a/src/libaudgui/ui_jumptotrack.c
+++ b/src/libaudgui/ui_jumptotrack.c
@@ -144,6 +144,17 @@ static bool_t keypress_cb (GtkWidget * widget, GdkEventKey * event)
     return FALSE;
 }
 
+static void set_starting_position(void)
+{
+    int playlist = aud_playlist_get_active();
+    int pos = aud_playlist_get_position (playlist);
+    GtkTreeSelection * sel = gtk_tree_view_get_selection ((GtkTreeView *) treeview);
+    GtkTreePath * path = gtk_tree_path_new_from_indices (pos, -1);
+    gtk_tree_selection_select_path (sel, path);
+    gtk_tree_view_scroll_to_cell ((GtkTreeView *) treeview, path, NULL, TRUE, 0.5, 0);
+    gtk_tree_path_free (path);
+}
+
 static void fill_list (void)
 {
     g_return_if_fail (treeview && filter_entry);
@@ -162,6 +173,7 @@ static void fill_list (void)
         GtkTreeSelection * sel = gtk_tree_view_get_selection ((GtkTreeView *) treeview);
         GtkTreePath * path = gtk_tree_path_new_from_indices (0, -1);
         gtk_tree_selection_select_path (sel, path);
+        gtk_tree_view_scroll_to_cell ((GtkTreeView *) treeview, path, NULL, TRUE, 0.5, 0);
         gtk_tree_path_free (path);
     }
 }
@@ -340,6 +352,7 @@ EXPORT void audgui_jump_to_track (void)
     if (! watching)
     {
         fill_list ();
+        set_starting_position();
         hook_associate ("playlist update", update_cb, NULL);
         hook_associate ("playlist activate", activate_cb, NULL);
         watching = TRUE;


### PR DESCRIPTION
This is the only bit of XMMS functionality that I missed when switching to Audacious. Everything else was an improvement, as I'm sure you've all heard many times before. Thanks for a great audio player!
