### PR TITLE
Fix wrong macro not returning a bool_t value

### DIFF
--- a/src/libaudgui/plugin-prefs.c
+++ b/src/libaudgui/plugin-prefs.c
@@ -67,7 +67,7 @@ static bool_t watch_cb (PluginHandle * plugin, void * window)
     {
         list = & config_windows;
         node = g_list_find (* list, window);
-        g_return_if_fail (node);
+        g_return_val_if_fail (node, FALSE);
     }
 
     g_signal_handlers_disconnect_by_func (window, destroy_cb, plugin);


### PR DESCRIPTION
`src/libaudgui/plugin-prefs.c::watch_cb` requires a value to be returned.

I wonder if you guys are using a different version of GLib? Using 2.40.0 here.
