### PR TITLE
Add SOCKS proxy support.

### DIFF
--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -259,6 +259,16 @@ static const PreferencesWidget connectivity_page_widgets[] = {
     WidgetCheck (N_("Use authentication with proxy"),
         WidgetBool (0, "use_proxy_auth")),
     WidgetTable ({{proxy_auth_elements}},
+        WIDGET_CHILD),
+    WidgetCheck (N_("SOCKS proxy?"),
+        WidgetBool (0, "socks_proxy")),
+    WidgetRadio (N_("SOCKS v4a"),
+        WidgetInt (0, "socks_type"),
+        {0},
+        WIDGET_CHILD),
+    WidgetRadio (N_("SOCKS v5"),
+        WidgetInt (0, "socks_type"),
+        {1},
         WIDGET_CHILD)
 };
 

--- a/src/libaudqt/prefs-window.cc
+++ b/src/libaudqt/prefs-window.cc
@@ -225,6 +225,15 @@ static const PreferencesWidget proxy_auth_elements[] = {
         {true})
 };
 
+static const PreferencesWidget proxy_socks_elements[] = {
+    WidgetRadio (N_("SOCKS v4a"),
+        WidgetInt (0, "socks_type"),
+        {0}),
+    WidgetRadio (N_("SOCKS v5"),
+        WidgetInt (0, "socks_type"),
+        {1})
+};
+
 static const PreferencesWidget connectivity_page_widgets[] = {
     WidgetLabel (N_("<b>Network Settings</b>")),
     WidgetSpin (N_("Buffer size:"),
@@ -238,6 +247,10 @@ static const PreferencesWidget connectivity_page_widgets[] = {
     WidgetCheck (N_("Use authentication with proxy"),
         WidgetBool (0, "use_proxy_auth")),
     WidgetTable ({{proxy_auth_elements}},
+        WIDGET_CHILD),
+    WidgetCheck (N_("SOCKS proxy?"),
+        WidgetBool (0, "socks_proxy")),
+    WidgetTable ({{proxy_socks_elements}},
         WIDGET_CHILD)
 };
 


### PR DESCRIPTION
Hi, I've added support for SOCKS proxy.  Please review/comment and merge if you agree with it. There is also a second part in audacious-plugins.

I've tested it with GTK+ 2/3 (Linux) and Qt (Linux and Windows).

Note that in libaudgui/prefs-window.cc I did not put radio buttons to proxy_socks_elements[] because they were not showing up.  For libaudqt/prefs-window.cc it works that way.
