### PR TITLE
Automatic ReplayGain mode based on shuffle.

### DIFF
--- a/src/libaudcore/config.cc
+++ b/src/libaudcore/config.cc
@@ -72,7 +72,7 @@ static const char * const core_defaults[] = {
  "output_bit_depth", "-1",
  "output_buffer_size", "500",
  "record_stream", aud::numeric_string<(int) OutputStream::AfterReplayGain>::str,
- "replay_gain_album", "FALSE",
+ "replay_gain_mode", aud::numeric_string<(int) ReplayGainMode::Automatic>::str,
  "replay_gain_preamp", "0",
  "soft_clipping", "FALSE",
  "software_volume_control", "FALSE",

--- a/src/libaudcore/output.cc
+++ b/src/libaudcore/output.cc
@@ -276,16 +276,22 @@ static void apply_replay_gain (Index<float> & data)
     {
         float peak;
 
-        if (aud_get_bool (0, "replay_gain_album"))
+        bool album = false;
+        switch(aud_get_int (0, "replay_gain_mode"))
         {
-            factor *= powf (10, gain_info.album_gain / 20);
-            peak = gain_info.album_peak;
+            case (int) ReplayGainMode::Album:
+                album = true;
+                break;
+            case (int) ReplayGainMode::Track:
+                album = false;
+                break;
+            case (int) ReplayGainMode::Automatic:
+            default:
+                album = ! (aud_get_bool (0, "shuffle") && ! aud_get_bool (0, "album_shuffle"));
+                break;
         }
-        else
-        {
-            factor *= powf (10, gain_info.track_gain / 20);
-            peak = gain_info.track_peak;
-        }
+        factor *= powf (10, album ? gain_info.album_gain : gain_info.track_gain / 20);
+        peak = album ? gain_info.album_peak : gain_info.track_peak;
 
         if (aud_get_bool (0, "enable_clipping_prevention") && peak * factor > 1)
             factor = 1 / peak;

--- a/src/libaudcore/runtime.h
+++ b/src/libaudcore/runtime.h
@@ -52,6 +52,12 @@ enum class OutputStream {
     AfterEqualizer
 };
 
+enum class ReplayGainMode {
+    Album,
+    Track,
+    Automatic
+};
+
 namespace audlog
 {
     enum Level {

--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -139,6 +139,12 @@ static const ComboItem record_elements[] = {
     ComboItem (N_("After applying equalization"), (int) OutputStream::AfterEqualizer)
 };
 
+static const ComboItem replaygainmode_elements[] = {
+    ComboItem (N_("Album"), (int) ReplayGainMode::Album),
+    ComboItem (N_("Track"), (int) ReplayGainMode::Track),
+    ComboItem (N_("Based on Shuffle"), (int) ReplayGainMode::Automatic)
+};
+
 static Index<ComboItem> iface_combo_elements;
 static int iface_combo_selected;
 static GtkWidget * iface_prefs_box;
@@ -221,9 +227,9 @@ static const PreferencesWidget audio_page_widgets[] = {
     WidgetLabel (N_("<b>ReplayGain</b>")),
     WidgetCheck (N_("Enable ReplayGain"),
         WidgetBool (0, "enable_replay_gain")),
-    WidgetCheck (N_("Album mode"),
-        WidgetBool (0, "replay_gain_album"),
-        WIDGET_CHILD),
+    WidgetCombo (N_("Mode"),
+        WidgetInt (0, "replay_gain_mode"),
+        {{replaygainmode_elements}}),
     WidgetCheck (N_("Prevent clipping (recommended)"),
         WidgetBool (0, "enable_clipping_prevention"),
         WIDGET_CHILD),

--- a/src/libaudqt/prefs-window.cc
+++ b/src/libaudqt/prefs-window.cc
@@ -136,6 +136,12 @@ static const ComboItem bitdepth_elements[] = {
     ComboItem (N_("Floating point"), 0)
 };
 
+static const ComboItem replaygainmode_elements[] = {
+    ComboItem (N_("Album"), (int) ReplayGainMode::Album),
+    ComboItem (N_("Track"), (int) ReplayGainMode::Track),
+    ComboItem (N_("Based on Shuffle"), (int) ReplayGainMode::Automatic)
+};
+
 static Index<ComboItem> iface_combo_elements;
 static int iface_combo_selected;
 static QWidget * iface_prefs_box;
@@ -198,9 +204,9 @@ static const PreferencesWidget audio_page_widgets[] = {
     WidgetLabel (N_("<b>ReplayGain</b>")),
     WidgetCheck (N_("Enable ReplayGain"),
         WidgetBool (0, "enable_replay_gain")),
-    WidgetCheck (N_("Album mode"),
-        WidgetBool (0, "replay_gain_album"),
-        WIDGET_CHILD),
+    WidgetCombo (N_("Mode"),
+        WidgetInt (0, "replay_gain_mode"),
+        {{replaygainmode_elements}}),
     WidgetCheck (N_("Prevent clipping (recommended)"),
         WidgetBool (0, "enable_clipping_prevention"),
         WIDGET_CHILD),


### PR DESCRIPTION
Removes "ReplayGain Album Mode" checkbox.

Adds "Mode" dropdown with "Album", "Track", "Based on Shuffle" options.

"Based on Shuffle" will use :
- "Track" gain if "Shuffle" is on.
- "Album" gain if "Album Shuffle" is on (even if "Shuffle" is on, since tracks within an album are played in order with "Album Shuffle").
- "Album" gain "Shuffle" is off.

See https://github.com/audacious-media-player/audacious-plugins/pull/49 for more info.