### PR TITLE
Adding stop after each song option

### DIFF
--- a/man/audacious.1.in
+++ b/man/audacious.1.in
@@ -112,6 +112,8 @@ Control + n			Toggle advancing in playlist
 .br
 Control + m			Toggle stopping after current song
 .br
+Control + b			Toggle stopping after each song
+.br
 Control + e			Display Equalizer
 .br
 Control + y			Display Search Tool

--- a/man/audtool.1.in
+++ b/man/audtool.1.in
@@ -221,6 +221,12 @@ Print the ``stop after current song'' option (``on'' or ``off'').
 .TP
 .B --playlist-stop-after-toggle
 Toggle the ``stop after current song'' option.
+.TP
+.B --playlist-stop-after-each-status
+Print the ``stop after each song'' option (``on'' or ``off'').
+.TP
+.B --playlist-stop-after-each-toggle
+Toggle the ``stop after each song'' option.
 
 .SS More playlist commands:
 

--- a/src/audacious/dbus-server.cc
+++ b/src/audacious/dbus-server.cc
@@ -690,6 +690,12 @@ static gboolean do_stop_after (Obj * obj, Invoc * invoc)
     return true;
 }
 
+static gboolean do_stop_after_each (Obj * obj, Invoc * invoc)
+{
+    FINISH2 (stop_after_each, aud_get_bool (nullptr, "stop_after_each_song"));
+    return true;
+}
+
 static gboolean do_stopped (Obj * obj, Invoc * invoc)
 {
     FINISH2 (stopped, ! aud_drct_get_playing ());
@@ -727,6 +733,13 @@ static gboolean do_toggle_stop_after (Obj * obj, Invoc * invoc)
 {
     aud_toggle_bool (nullptr, "stop_after_current_song");
     FINISH (toggle_stop_after);
+    return true;
+}
+
+static gboolean do_toggle_stop_after_each (Obj * obj, Invoc * invoc)
+{
+    aud_toggle_bool (nullptr, "stop_after_each_song");
+    FINISH (toggle_stop_after_each);
     return true;
 }
 
@@ -826,12 +839,14 @@ handlers[] =
     {"handle-status", (GCallback) do_status},
     {"handle-stop", (GCallback) do_stop},
     {"handle-stop-after", (GCallback) do_stop_after},
+    {"handle-stop-after-each", (GCallback) do_stop_after_each},
     {"handle-stopped", (GCallback) do_stopped},
     {"handle-time", (GCallback) do_time},
     {"handle-toggle-auto-advance", (GCallback) do_toggle_auto_advance},
     {"handle-toggle-repeat", (GCallback) do_toggle_repeat},
     {"handle-toggle-shuffle", (GCallback) do_toggle_shuffle},
     {"handle-toggle-stop-after", (GCallback) do_toggle_stop_after},
+    {"handle-toggle-stop-after-each", (GCallback) do_toggle_stop_after_each},
     {"handle-version", (GCallback) do_version},
     {"handle-volume", (GCallback) do_volume}
 };

--- a/src/audtool/audtool.h
+++ b/src/audtool/audtool.h
@@ -84,6 +84,8 @@ void playlist_shuffle_status (int, char * *);
 void playlist_shuffle_toggle (int, char * *);
 void playlist_stop_after_status (int argc, char * * argv);
 void playlist_stop_after_toggle (int argc, char * * argv);
+void playlist_stop_after_each_status (int argc, char * * argv);
+void playlist_stop_after_each_toggle (int argc, char * * argv);
 void playlist_tuple_field_data (int, char * * argv);
 void playlist_enqueue_to_temp (int argc, char * * argv);
 void playlist_ins_url_string (int argc, char * * argv);

--- a/src/audtool/handlers_playlist.c
+++ b/src/audtool/handlers_playlist.c
@@ -68,6 +68,18 @@ void playlist_stop_after_toggle (int argc, char * * argv)
     obj_audacious_call_toggle_stop_after_sync (dbus_proxy, NULL, NULL);
 }
 
+void playlist_stop_after_each_status (int argc, char * * argv)
+{
+    gboolean stop_after_each = FALSE;
+    obj_audacious_call_stop_after_each_sync (dbus_proxy, & stop_after_each, NULL, NULL);
+    audtool_report (stop_after_each ? "on" : "off");
+}
+
+void playlist_stop_after_each_toggle (int argc, char * * argv)
+{
+    obj_audacious_call_toggle_stop_after_each_sync (dbus_proxy, NULL, NULL);
+}
+
 int check_args_playlist_pos (int argc, char * * argv)
 {
     int pos;

--- a/src/audtool/main.c
+++ b/src/audtool/main.c
@@ -86,6 +86,8 @@ const struct commandhandler handlers[] =
     {"playlist-shuffle-toggle", playlist_shuffle_toggle, "toggle playlist shuffle", 0},
     {"playlist-stop-after-status", playlist_stop_after_status, "query if stopping after current song", 0},
     {"playlist-stop-after-toggle", playlist_stop_after_toggle, "toggle if stopping after current song", 0},
+    {"playlist-stop-after-each-status", playlist_stop_after_each_status, "query if stopping after each song", 0},
+    {"playlist-stop-after-each-toggle", playlist_stop_after_each_toggle, "toggle if stopping after each song", 0},
 
     {"<sep>", NULL, "More playlist commands", 0},
     {"number-of-playlists", number_of_playlists, "print number of playlists", 0},

--- a/src/dbus/aud-dbus.xml
+++ b/src/dbus/aud-dbus.xml
@@ -395,6 +395,14 @@
         <!-- Toggle stop-after-song -->
         <method name="ToggleStopAfter" />
 
+        <!-- Query stop-after-each-song status -->
+        <method name="StopAfterEach">
+            <arg type="b" direction="out" name="is_stopping_each"/>
+        </method>
+
+        <!-- Toggle stop-after-each-song -->
+        <method name="ToggleStopAfterEach" />
+
         <!-- Playlist Queue -->
         <!-- ++++++++++++++ -->
 

--- a/src/libaudcore/config.cc
+++ b/src/libaudcore/config.cc
@@ -87,6 +87,7 @@ static const char * const core_defaults[] = {
  "repeat", "FALSE",
  "shuffle", "FALSE",
  "stop_after_current_song", "FALSE",
+ "stop_after_each_song", "FALSE",
 
  /* playlist */
  "chardet_fallback", "ISO-8859-1",

--- a/src/libaudcore/playback.cc
+++ b/src/libaudcore/playback.cc
@@ -256,7 +256,8 @@ static void end_cb (void *)
         // single-song repeats are handled in run_playback()
         do_stop ();
     }
-    else if (aud_get_bool (nullptr, "stop_after_current_song"))
+    else if (aud_get_bool (nullptr, "stop_after_current_song") ||
+     aud_get_bool (nullptr, "stop_after_each_song"))
     {
         do_stop ();
         do_next ();


### PR DESCRIPTION
Add the option to stop playback after each song.

I use audacious to play tracks in live shows. I need that after each song the playback stops and the position of the playlist is advanced. That is like a permanent "Stop after current song".

See: https://github.com/audacious-media-player/audacious-plugins/pull/61