### PR TITLE
Pass "audacious" to gtk_init as argv[0] so that WM_CLASS gets set coreectly

### DIFF
--- a/src/libaudgui/init.cc
+++ b/src/libaudgui/init.cc
@@ -335,12 +335,17 @@ static void playlist_position_cb (void * list, void *)
 EXPORT void audgui_init ()
 {
     static bool icons_loaded = false;
+    /* Dummy args to get gtk to set WM_CLASS */
+    int argc = 1;
+    char *_argv[] = { "audacious", NULL };
+    char **argv = _argv;
+
     assert (aud_get_mainloop_type () == MainloopType::GLib);
 
     if (init_count ++)
         return;
 
-    gtk_init (nullptr, nullptr);
+    gtk_init (&argc, &argv);
 
     if (! icons_loaded)
     {


### PR DESCRIPTION
Before this commit the WM_CLASS of gtk2 builds of audacious-3.9 would be set to "<unknown>", "<unknown>".

This commit passes "audacious" to gtk_init as argv[0], which changes WM_CLASS to "audacious", "Audacious".

This fixes the Window title (in alt-tab) being <unknown> and a non svg icon being used under GNOME 3.28.