### PR TITLE
libaudqt: Fix crash when infopopup is being hidden

### DIFF
--- a/src/libaudqt/infopopup-qt.cc
+++ b/src/libaudqt/infopopup-qt.cc
@@ -176,7 +176,7 @@ static InfoPopup * s_infopopup;
 
 static void infopopup_show (const String & filename, const Tuple & tuple)
 {
-    delete s_infopopup;
+    if(s_infopopup) s_infopopup->deleteLater();
     s_infopopup = new InfoPopup (filename, tuple);
 
     QObject::connect (s_infopopup, & QObject::destroyed, [] () {
@@ -206,7 +206,7 @@ EXPORT void infopopup_show_current ()
 
 EXPORT void infopopup_hide ()
 {
-    delete s_infopopup;
+    s_infopopup->deleteLater();
 }
 
 } // namespace audqt


### PR DESCRIPTION
Hovering over the track I wanted to listen to showed a tool tip (the
InfoPopup widget); if I moved the mouse in any way after the widget was
displayed, it would immediately crash with a segmentation fault.

Valgrind showed that this was due to s_infopopup being deleted from an
event that involved it.  By switching both `delete` to `deleteLater`,
the crash no longer occurs.

Closes: #828.