### PR TITLE
misc Makefile: move build artifacts dirs into *LDFLAGS variable.

### DIFF
--- a/src/audacious/Makefile
+++ b/src/audacious/Makefile
@@ -28,7 +28,9 @@ CPPFLAGS := -I.. -I../.. \
             ${CPPFLAGS} \
             ${GLIB_CFLAGS}
 
-LIBS := -L../libaudcore -laudcore \
+LDFLAGS := -L../libaudcore $(LDFLAGS)
+
+LIBS := -laudcore \
         ${LIBS} -lm \
         ${LIBINTL} \
         ${GLIB_LIBS}

--- a/src/libaudgui/Makefile
+++ b/src/libaudgui/Makefile
@@ -52,7 +52,9 @@ CPPFLAGS := -I.. -I../.. \
 
 CFLAGS += ${LIB_CFLAGS}
 
-LIBS := -L../libaudcore -laudcore \
+LIB_LDFLAGS := -L../libaudcore $(LIB_LDFLAGS)
+
+LIBS := -laudcore \
         ${LIBS} -lm \
         ${GLIB_LIBS} \
         ${GTK_LIBS}

--- a/src/libaudqt/Makefile
+++ b/src/libaudqt/Makefile
@@ -52,7 +52,9 @@ CPPFLAGS := -I.. -I../.. \
 
 CFLAGS += ${LIB_CFLAGS}
 
-LIBS := -L../libaudcore -laudcore \
+LIB_LDFLAGS := -L../libaudcore $(LIB_LDFLAGS)
+
+LIBS := -laudcore \
         ${LIBS} -lm \
         ${QT_LIBS}
 

--- a/src/libaudtag/Makefile
+++ b/src/libaudtag/Makefile
@@ -24,6 +24,8 @@ CPPFLAGS := -I.. -I../.. \
 
 CFLAGS += ${LIB_CFLAGS}
 
-LIBS := -L../libaudcore -laudcore \
+LIB_LDFLAGS := -L../libaudcore $(LIB_LDFLAGS)
+
+LIBS := -laudcore \
         ${LIBS} \
         ${GLIB_LIBS}


### PR DESCRIPTION
`${LDFLAGS}` often contains additional (system) library directories that
also often contain old/already installed versions of the libraries to be
linked and are passed via `${LIBS}`. While `${LIBS}` pretty much always
contains `-Llocal_build_dir` to make the linker/compiler pick the newly
built library for the later referenced libraries, that location will be
overridden and the build system hence eventually tries to link against
the old system library.

This issue is not seen often on Linux-based systems (since they don't
need to supply additional system library directories), but abundant on
others.

For instance, on macOS with MacPorts, `LDFLAGS` contains `-L${prefix}/lib`
(with `/opt/local` being the default prefix).

This leads to link calls such as these:

```
$LD ... -L${prefix}/lib ... -L../libaudcore -laudcore ...
```

which will, sadly, pick `libaudcore` from `${prefix}/lib` if audacious has
been previously installed there.

According to the autotools documentation, `-L` flags belong to the `LDFLAGS`
variable and `-l` flags to the `LIBS` variable. Hence, split up `-L` and `-l`
flags (if possible) and prepend `-L` flags to the corresponding `LDFLAGS`
variable in order to let it have precedence.