### PR TITLE
Fix accidental assignment instead of compare in Tuple::is_same.

### DIFF
--- a/src/libaudcore/tuple.cc
+++ b/src/libaudcore/tuple.cc
@@ -368,7 +368,7 @@ bool TupleData::is_same(const TupleData & other)
             if (field_info[f].type == Tuple::String)
                 same = (a->str == b->str);
             else
-                same = (a->x = b->x);
+                same = (a->x == b->x);
 
             if (!same)
                 return false;


### PR DESCRIPTION
I'm writing a plugin where the possibly only tuple info that may get updated upon playback is the duration. Noticed nothing was happening, when set_playback_tuple was called, although read_tags works, since that path apparently doesn't depend on this test.