### PR TITLE
Add "X-GNOME-SingleWindow=true" to the desktop file

### DIFF
--- a/audacious.desktop
+++ b/audacious.desktop
@@ -11,6 +11,7 @@ TryExec=audacious
 StartupNotify=false
 Terminal=false
 MimeType=application/ogg;application/x-cue;application/x-ogg;application/xspf+xml;audio/aac;audio/flac;audio/midi;audio/mp3;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/prs.sid;audio/wav;audio/x-flac;audio/x-it;audio/x-mod;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-asx;audio/x-ms-wma;audio/x-musepack;audio/x-s3m;audio/x-scpls;audio/x-stm;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-xm;x-content/audio-cdda;
+X-GNOME-SingleWindow=true
 
 Comment[ar]=استمع إلى الموسيقى
 Comment[be]=Слухайце музыку


### PR DESCRIPTION
Since this commit (https://github.com/KDE/plasma-workspace/commit/ebd2acd98ecdb9d115b01bd01f532390376152f7),
Plasma Desktop will check "X-GNOME-SingleWindow" property to determine
whether to show "Open New Window" action in the context menu of a task.

Audacious cannot launch a new instance or open a new window, so add the
property and set it to true to hide the action.

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/23738961/147640798-d66ad00a-c0af-4af1-9cf8-c39549beb80e.png)|![after](https://user-images.githubusercontent.com/23738961/147640820-6fec3537-e4a7-472b-8956-ee5a90512727.png)|