### PR TITLE
Change X-GNOME-SingleWindow key to SingleMainWindow

### DIFF
--- a/audacious.desktop
+++ b/audacious.desktop
@@ -11,7 +11,7 @@ TryExec=audacious
 StartupNotify=false
 Terminal=false
 MimeType=application/ogg;application/x-cue;application/x-ogg;application/xspf+xml;audio/aac;audio/flac;audio/midi;audio/mp3;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/prs.sid;audio/wav;audio/x-flac;audio/x-it;audio/x-mod;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-asx;audio/x-ms-wma;audio/x-musepack;audio/x-s3m;audio/x-scpls;audio/x-stm;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-xm;x-content/audio-cdda;
-X-GNOME-SingleWindow=true
+SingleMainWindow=true
 
 Comment[ar]=استمع إلى الموسيقى
 Comment[be]=Слухайце музыку


### PR DESCRIPTION
X-GNOME-SingleWindow was upstreamed to be an XDG spec with the name "SingleMainWindow" in https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53