### PR TITLE
Open directory select dialog when directory needs to be selected

### DIFF
--- a/src/libaudqt/fileopener.cc
+++ b/src/libaudqt/fileopener.cc
@@ -72,7 +72,10 @@ EXPORT void fileopener_show(FileMode mode)
         dialog = new QFileDialog(nullptr, _(titles[mode]), QString(path));
 
         dialog->setAttribute(Qt::WA_DeleteOnClose);
-        dialog->setFileMode(modes[mode]);
+        QFileDialog::FileMode file_mode = modes[mode];
+        dialog->setFileMode(file_mode);
+        if (file_mode == QFileDialog::FileMode::Directory)
+            dialog->setOption(QFileDialog::ShowDirsOnly);
         dialog->setLabelText(QFileDialog::Accept, _(labels[mode]));
         dialog->setLabelText(QFileDialog::Reject, _("Cancel"));
 


### PR DESCRIPTION
Tested on Manjaro KDE, but should work everywhere.

Before:
![audacious_folder_select_before](https://user-images.githubusercontent.com/54238857/166135392-c6369970-c0f0-4819-b070-d628d76f66fa.png)
After:
![audacious_folder_select_after](https://user-images.githubusercontent.com/54238857/166135542-a890d5e9-e4ea-42d7-8eb7-22f8fef1cca7.png)
