### PR TITLE
WIP: Change gettext stubs to fix build without gettext.

### DIFF
--- a/src/libaudcore/i18n.h
+++ b/src/libaudcore/i18n.h
@@ -34,9 +34,8 @@
 
 #else
 
-#define _(String) ((char *)String)
+#define _(String) (String)
 #define N_(String) (String)
-#define gettext(str) (str)
 #define dgettext(package, str) (str)
 #define dngettext(package, str1, str2, count) (count > 1 ? str2 : str1)
 #define ngettext(str1, str2, count) (count > 1 ? str2 : str1)

--- a/src/libaudcore/i18n.h
+++ b/src/libaudcore/i18n.h
@@ -34,8 +34,9 @@
 
 #else
 
-#define _(String) (String)
+#define _(String) ((char *)String)
 #define N_(String) (String)
+#define gettext(str) (str)
 #define dgettext(package, str) (str)
 #define dngettext(package, str1, str2, count) (count > 1 ? str2 : str1)
 #define ngettext(str1, str2, count) (count > 1 ? str2 : str1)

--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -531,7 +531,7 @@ static void fill_category_list (GtkTreeView * treeview, GtkNotebook * notebook)
         GtkTreeIter iter;
         gtk_list_store_append (store, & iter);
         gtk_list_store_set (store, & iter, CATEGORY_VIEW_COL_NAME,
-         gettext (category.name), -1);
+         _(category.name), -1);
 
         AudguiPixbuf img (gtk_icon_theme_load_icon (icon_theme,
          category.icon, icon_size, (GtkIconLookupFlags) 0, nullptr));


### PR DESCRIPTION
These changes are required to build audacious on FreeBSD when passing --disable-nls to configure.

- Change _() to strip const from the string.

This one is used in https://github.com/audacious-media-player/audacious/blob/73a881fb59bb27f60654b63a95d8c3de73a026ae/src/libaudgui/infowin.cc#L265

It fails due to the const qualifier

- Add a gettext() stub

This is used in https://github.com/audacious-media-player/audacious/blob/73a881fb59bb27f60654b63a95d8c3de73a026ae/src/libaudgui/prefs-window.cc#L534

Which does not look FreeBSD specific.