### PR TITLE
Add publisher and catalog number

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl Initialize
 dnl ==========
 
 AC_PREREQ([2.59])
-AC_INIT([audacious], [4.2])
+AC_INIT([audacious], [4.3-devel])
 AC_COPYRIGHT([Copyright (C) 2001-2022 Audacious developers and others])
 
 AC_DEFINE_UNQUOTED(PACKAGE, "$PACKAGE_NAME", [Name of package])

--- a/src/libaudcore/Makefile
+++ b/src/libaudcore/Makefile
@@ -1,6 +1,6 @@
 SHARED_LIB = ${LIB_PREFIX}audcore${LIB_SUFFIX}
 LIB_MAJOR = 5
-LIB_MINOR = 3
+LIB_MINOR = 4
 
 SRCS = adder.cc \
        archive_reader.cc \

--- a/src/libaudcore/playlist-utils.cc
+++ b/src/libaudcore/playlist-utils.cc
@@ -121,6 +121,14 @@ static int tuple_compare_comment(const Tuple & a, const Tuple & b)
 {
     return tuple_compare_string(a, b, Tuple::Comment);
 }
+static int tuple_compare_publisher(const Tuple & a, const Tuple & b)
+{
+    return tuple_compare_string(a, b, Tuple::Publisher);
+}
+static int tuple_compare_catalog_number(const Tuple & a, const Tuple & b)
+{
+    return tuple_compare_string(a, b, Tuple::CatalogNum);
+}
 
 static const Playlist::StringCompareFunc filename_comparisons[] = {
     filename_compare_path,     // path
@@ -134,7 +142,9 @@ static const Playlist::StringCompareFunc filename_comparisons[] = {
     nullptr,                   // track
     nullptr,                   // formatted title
     nullptr,                   // length
-    nullptr                    // comment
+    nullptr,                   // comment
+    nullptr,                   // publisher
+    nullptr                    // catalog number
 };
 
 static const Playlist::TupleCompareFunc tuple_comparisons[] = {
@@ -149,7 +159,9 @@ static const Playlist::TupleCompareFunc tuple_comparisons[] = {
     tuple_compare_track,
     tuple_compare_formatted_title,
     tuple_compare_length,
-    tuple_compare_comment};
+    tuple_compare_comment,
+    tuple_compare_publisher,
+    tuple_compare_catalog_number};
 
 static_assert(aud::n_elems(filename_comparisons) == Playlist::n_sort_types &&
                   aud::n_elems(tuple_comparisons) == Playlist::n_sort_types,

--- a/src/libaudcore/playlist.h
+++ b/src/libaudcore/playlist.h
@@ -76,6 +76,8 @@ public:
         FormattedTitle,
         Length,
         Comment,
+        Publisher,
+        CatalogNum,
         n_sort_types
     };
 

--- a/src/libaudcore/tuple.cc
+++ b/src/libaudcore/tuple.cc
@@ -148,6 +148,8 @@ static const struct
     {"description", Tuple::String, -1},
     {"musicbrainz-id", Tuple::String, -1},
     {"channels", Tuple::Int, -1},
+    {"publisher", Tuple::String, -1},
+    {"catalog-number", Tuple::String, -1},
 
     /* fallbacks */
     {nullptr, Tuple::String, -1},
@@ -171,6 +173,7 @@ static const FieldDictEntry field_dict[] = {
     {"artist", Tuple::Artist},
     {"audio-file", Tuple::AudioFile},
     {"bitrate", Tuple::Bitrate},
+    {"catalog-number", Tuple::CatalogNum},
     {"channels", Tuple::Channels},
     {"codec", Tuple::Codec},
     {"comment", Tuple::Comment},
@@ -192,6 +195,7 @@ static const FieldDictEntry field_dict[] = {
     {"length", Tuple::Length},
     {"musicbrainz-id", Tuple::MusicBrainzID},
     {"performer", Tuple::Performer},
+    {"publisher", Tuple::Publisher},
     {"quality", Tuple::Quality},
     {"segment-end", Tuple::EndTime},
     {"segment-start", Tuple::StartTime},

--- a/src/libaudcore/tuple.h
+++ b/src/libaudcore/tuple.h
@@ -106,6 +106,8 @@ public:
         Description,   /* Track description */
         MusicBrainzID, /* MusicBrainz identifier */
         Channels, /* Track channels count */
+        Publisher,  /* Publisher (label) */
+        CatalogNum, /* Catalog number */
 
         n_fields
     };

--- a/src/libaudqt/info-widget.cc
+++ b/src/libaudqt/info-widget.cc
@@ -57,6 +57,8 @@ static const TupleFieldMap tuple_field_map[] = {
     {N_("Performer"), Tuple::Performer, true},
     {N_("Recording Year"), Tuple::Year, true},
     {N_("Recording Date"), Tuple::Date, true},
+    {N_("Publisher"), Tuple::Publisher, false},
+    {N_("Catalog Number"), Tuple::CatalogNum, false},
 
     {nullptr, Tuple::Invalid, false},
     {N_("Technical"), Tuple::Invalid, false},

--- a/src/libaudtag/id3/id3-common.cc
+++ b/src/libaudtag/id3/id3-common.cc
@@ -292,7 +292,9 @@ void id3_decode_txxx (Tuple & tuple, const char * data, int size)
 
     if (key && value)
     {
-        if (! strcmp_nocase (key, "REPLAYGAIN_TRACK_GAIN"))
+        if (! strcmp_nocase (key, "CATALOGNUMBER"))
+            tuple.set_str(Tuple::CatalogNum, value);
+        else if (! strcmp_nocase (key, "REPLAYGAIN_TRACK_GAIN"))
             tuple.set_gain (Tuple::TrackGain, Tuple::GainDivisor, value);
         else if (! strcmp_nocase (key, "REPLAYGAIN_TRACK_PEAK"))
             tuple.set_gain (Tuple::TrackPeak, Tuple::PeakDivisor, value);

--- a/src/libaudtag/id3/id3v24.cc
+++ b/src/libaudtag/id3/id3v24.cc
@@ -52,6 +52,7 @@ enum
     ID3_COMMENT,
     ID3_ENCODER,
     ID3_RECORDING_TIME,
+    ID3_PUBLISHER,
     ID3_TXXX,
     ID3_RVA2,
     ID3_APIC,
@@ -73,6 +74,7 @@ static const char * id3_frames[ID3_TAGS_NO] = {
     "COMM",
     "TSSE",
     "TDRC",
+    "TPUB",
     "TXXX",
     "RVA2",
     "APIC"
@@ -595,6 +597,9 @@ bool ID3v24TagModule::read_tag (VFSFile & handle, Tuple & tuple, Index<char> * i
           case ID3_YEAR:
           case ID3_RECORDING_TIME:
             id3_associate_int (tuple, Tuple::Year, & frame[0], frame.len ());
+            break;
+          case ID3_PUBLISHER:
+            id3_associate_string (tuple, Tuple::Publisher, & frame[0], frame.len ());
             break;
           case ID3_GENRE:
             id3_decode_genre (tuple, & frame[0], frame.len ());


### PR DESCRIPTION
I wanted to see the publisher (label) and catalog number tags in a playlist, but noticed that it wasn't implemented. This adds `Publisher` and `CatalogNum` to `Tuple` as well as support for ID3v2.4 tags.

Corresponding plugins PR to add support to qtui, gtkui, flac, and vorbis: audacious-media-player/audacious-plugins#111

![Screenshot from 2022-09-07 15-48-48](https://user-images.githubusercontent.com/114056/188998335-3922c3ca-e27d-4eb4-a143-663032d45346.png)

![image](https://user-images.githubusercontent.com/114056/188999982-fb487b44-e3d4-4423-bad6-20e236819634.png)

