### PR TITLE
audgui: Restore GTK3 support

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -184,6 +184,18 @@ AC_DEFINE([GLIB_VERSION_MIN_REQUIRED], [GLIB_VERSION_2_32], [target GLib 2.32])
 dnl GTK+ support
 dnl =============
 
+AC_ARG_ENABLE(gtk3,
+ AS_HELP_STRING(--enable-gtk3, [Use GTK3 instead of GTK2 (default=disabled)]),
+ USE_GTK3=$enableval, USE_GTK3=no)
+
+if test $USE_GTK3 = yes ; then
+    PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.22)
+    AC_DEFINE(USE_GTK, 1, [Define if GTK+ support enabled])
+    AC_DEFINE(USE_GTK3, 1, [Define if GTK3+ support enabled])
+fi
+
+AC_SUBST(USE_GTK3)
+
 AC_ARG_ENABLE(gtk,
  AS_HELP_STRING(--disable-gtk, [Disable GTK+ support (default=enabled)]),
  USE_GTK=$enableval, USE_GTK=yes)

--- a/meson.build
+++ b/meson.build
@@ -39,8 +39,13 @@ endif
 
 
 if get_option('gtk')
-  gtk_req = '>= 2.24'
-  gtk_dep = dependency('gtk+-2.0', version: gtk_req, required: true)
+  if get_option('gtk3')
+    gtk_req = '>= 3.22'
+    gtk_dep = dependency('gtk+-3.0', version: gtk_req, required: true)
+  else
+    gtk_req = '>= 2.24'
+    gtk_dep = dependency('gtk+-2.0', version: gtk_req, required: true)
+  endif
 endif
 
 
@@ -155,6 +160,9 @@ endif
 
 if get_option('gtk')
   conf.set10('USE_GTK', true)
+  if (get_option('gtk3'))
+    conf.set10('USE_GTK3', true)
+  endif
 endif
 
 
@@ -211,7 +219,8 @@ if meson.version().version_compare('>= 0.53')
     'D-Bus support': get_option('dbus'),
     'Qt 5 support': get_option('qt') and not get_option('qt6'),
     'Qt 6 support': get_option('qt6'),
-    'GTK support': get_option('gtk'),
+    'GTK2 support': get_option('gtk') and not get_option('gtk3'),
+    'GTK3 support': get_option('gtk3'),
     'Libarchive support': get_option('libarchive'),
     'Valgrind analysis support': get_option('valgrind'),
     'Build stamp': get_option('buildstamp'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,8 @@ option('qt6', type: 'boolean', value: false,
        description: 'Whether Qt 6 support is enabled')
 option('gtk', type: 'boolean', value: true,
        description: 'Whether GTK support is enabled')
+option('gtk3', type: 'boolean', value: false,
+       description: 'Whether GTK3 support is enabled')
 option('libarchive', type: 'boolean', value: false,
        description: 'Whether libarchive support is enabled')
 option('buildstamp', type: 'string', value: 'unknown build',

--- a/src/config.h.meson
+++ b/src/config.h.meson
@@ -19,6 +19,7 @@
 #mesondefine USE_DBUS
 #mesondefine USE_QT
 #mesondefine USE_GTK
+#mesondefine USE_GTK3
 #mesondefine USE_LIBARCHIVE
 
 #define GLIB_VERSION_MIN_REQUIRED GLIB_VERSION_2_32

--- a/src/libaudgui/Makefile
+++ b/src/libaudgui/Makefile
@@ -7,6 +7,7 @@ SRCS = about.cc \
        eq-preset.cc \
        equalizer.cc \
        file-opener.cc \
+       gtk-compat.cc \
        images.c \
        infopopup.cc \
        infowin.cc \
@@ -31,7 +32,8 @@ SRCS = about.cc \
        url-opener.cc \
        util.cc
 
-INCLUDES = libaudgui.h \
+INCLUDES = gtk-compat.h \
+           libaudgui.h \
            libaudgui-gtk.h \
            list.h \
            menu.h

--- a/src/libaudgui/about.cc
+++ b/src/libaudgui/about.cc
@@ -24,6 +24,7 @@
 #include <libaudcore/runtime.h>
 #include <libaudcore/vfs.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -75,7 +76,7 @@ static GtkWidget * create_about_window ()
 
     audgui_destroy_on_escape (about_window);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_add ((GtkContainer *) about_window, vbox);
 
     AudguiPixbuf logo (gdk_pixbuf_new_from_resource_at_scale
@@ -88,11 +89,16 @@ static GtkWidget * create_about_window ()
     gtk_label_set_justify ((GtkLabel *) label, GTK_JUSTIFY_CENTER);
     gtk_box_pack_start ((GtkBox *) vbox, label, false, false, 0);
 
-    GtkWidget * align = gtk_alignment_new (0.5, 0.5, 0, 0);
-    gtk_box_pack_start ((GtkBox *) vbox, align, false, false, 0);
-
     GtkWidget * button = gtk_link_button_new (website);
+
+#ifdef USE_GTK3
+    gtk_widget_set_halign (button, GTK_ALIGN_CENTER);
+    gtk_box_pack_start ((GtkBox *) vbox, button, false, false, 0);
+#else
+    GtkWidget * align = gtk_alignment_new (0.5, 0.5, 0, 0);
     gtk_container_add ((GtkContainer *) align, button);
+    gtk_box_pack_start ((GtkBox *) vbox, align, false, false, 0);
+#endif
 
     auto credits = VFSFile::read_file (filename_build ({data_dir, "AUTHORS"}), VFS_APPEND_NULL);
     auto license = VFSFile::read_file (filename_build ({data_dir, "COPYING"}), VFS_APPEND_NULL);

--- a/src/libaudgui/eq-preset.cc
+++ b/src/libaudgui/eq-preset.cc
@@ -26,6 +26,7 @@
 #include <libaudcore/interface.h>
 #include <libaudcore/runtime.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -286,16 +287,16 @@ static GtkWidget * create_eq_preset_window ()
 
     g_signal_connect (window, "destroy", (GCallback) cleanup_eq_preset_window, nullptr);
 
-    GtkWidget * outer = gtk_vbox_new (false, 0);
+    GtkWidget * outer = audgui_vbox_new (0);
     gtk_container_add ((GtkContainer *) window, outer);
 
     gtk_box_pack_start ((GtkBox *) outer, create_menu_bar (), false, false, 0);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_set_border_width ((GtkContainer *) vbox, 6);
     gtk_box_pack_start ((GtkBox *) outer, vbox, true, true, 0);
 
-    GtkWidget * hbox = gtk_hbox_new (false, 6);
+    GtkWidget * hbox = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, hbox, false, false, 0);
 
     entry = gtk_entry_new ();
@@ -320,7 +321,7 @@ static GtkWidget * create_eq_preset_window ()
     audgui_list_add_column (list, nullptr, 0, G_TYPE_STRING, -1);
     gtk_container_add ((GtkContainer *) scrolled, list);
 
-    GtkWidget * hbox2 = gtk_hbox_new (false, 6);
+    GtkWidget * hbox2 = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, hbox2, false, false, 0);
 
     GtkWidget * remove = audgui_button_new (_("Delete Selected"), "edit-delete",

--- a/src/libaudgui/equalizer.cc
+++ b/src/libaudgui/equalizer.cc
@@ -25,6 +25,7 @@
 #include <libaudcore/i18n.h>
 #include <libaudcore/runtime.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -68,13 +69,16 @@ static void slider_moved (GtkRange * slider)
 
 static GtkWidget * create_slider (const char * name, int band, GtkWidget * hbox)
 {
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
 
     GtkWidget * label = gtk_label_new (name);
     gtk_label_set_angle ((GtkLabel *) label, 90);
     gtk_box_pack_start ((GtkBox *) vbox, label, true, false, 0);
 
-    GtkWidget * slider = gtk_vscale_new_with_range (-AUD_EQ_MAX_GAIN, AUD_EQ_MAX_GAIN, 1);
+    GtkAdjustment * adjustment = (GtkAdjustment *) gtk_adjustment_new (
+     0, -AUD_EQ_MAX_GAIN, AUD_EQ_MAX_GAIN, 1, 2, 0);
+    GtkWidget * slider = audgui_scale_new (GTK_ORIENTATION_VERTICAL, adjustment);
+    gtk_scale_set_digits ((GtkScale *) slider, 0);
     gtk_scale_set_draw_value ((GtkScale *) slider, true);
     gtk_scale_set_value_pos ((GtkScale *) slider, GTK_POS_BOTTOM);
     gtk_range_set_inverted ((GtkRange *) slider, true);
@@ -132,10 +136,10 @@ static GtkWidget * create_window ()
     gtk_container_set_border_width ((GtkContainer *) window, 6);
     audgui_destroy_on_escape (window);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_add ((GtkContainer *) window, vbox);
 
-    GtkWidget * top_row = gtk_hbox_new (false, 6);
+    GtkWidget * top_row = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, top_row, false, false, 0);
 
     gtk_box_pack_start ((GtkBox *) top_row, create_on_off (), false, false, 0);
@@ -148,13 +152,14 @@ static GtkWidget * create_window ()
      (AudguiCallback) reset_to_zero, nullptr);
     gtk_box_pack_end ((GtkBox *) top_row, zero, false, false, 0);
 
-    GtkWidget * hbox = gtk_hbox_new (false, 6);
+    GtkWidget * hbox = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, hbox, false, false, 0);
 
     GtkWidget * preamp = create_slider (_("Preamp"), -1, hbox);
     g_object_set_data ((GObject *) window, "preamp", preamp);
 
-    gtk_box_pack_start ((GtkBox *) hbox, gtk_vseparator_new (), false, false, 0);
+    gtk_box_pack_start ((GtkBox *) hbox,
+     audgui_separator_new (GTK_ORIENTATION_VERTICAL), false, false, 0);
 
     for (int i = 0; i < AUD_EQ_NBANDS; i ++)
     {

--- a/src/libaudgui/file-opener.cc
+++ b/src/libaudgui/file-opener.cc
@@ -25,6 +25,7 @@
 #include <libaudcore/runtime.h>
 #include <libaudcore/tuple.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -90,15 +91,20 @@ static GtkWidget * create_filebrowser (gboolean open)
         option = "close_dialog_add";
     }
 
+    int vbox_padding = 0;
     int dpi = audgui_get_dpi ();
 
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_title ((GtkWindow *) window, window_title);
     gtk_window_set_default_size ((GtkWindow *) window, 7 * dpi, 5 * dpi);
-    gtk_container_set_border_width ((GtkContainer *) window, 10);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 0);
+#ifndef USE_GTK3
+    vbox_padding = 3;
+    gtk_container_set_border_width ((GtkContainer *) window, 10);
+#endif
+
+    GtkWidget * vbox = audgui_vbox_new (0);
     gtk_container_add ((GtkContainer *) window, vbox);
 
     GtkWidget * chooser = gtk_file_chooser_widget_new (GTK_FILE_CHOOSER_ACTION_OPEN);
@@ -109,17 +115,21 @@ static GtkWidget * create_filebrowser (gboolean open)
     if (path[0])
         gtk_file_chooser_set_current_folder ((GtkFileChooser *) chooser, path);
 
-    gtk_box_pack_start ((GtkBox *) vbox, chooser, true, true, 3);
+    gtk_box_pack_start ((GtkBox *) vbox, chooser, true, true, vbox_padding);
 
-    GtkWidget * hbox = gtk_hbox_new (false, 0);
-    gtk_box_pack_end ((GtkBox *) vbox, hbox, false, false, 3);
+    GtkWidget * hbox = audgui_hbox_new (0);
+    gtk_box_pack_end ((GtkBox *) vbox, hbox, false, false, vbox_padding);
+
+#ifdef USE_GTK3
+    gtk_container_set_border_width ((GtkContainer *) hbox, 6);
+#endif
 
     GtkWidget * toggle = gtk_check_button_new_with_mnemonic (toggle_text);
     gtk_toggle_button_set_active ((GtkToggleButton *) toggle, aud_get_bool ("audgui", option));
     g_signal_connect (toggle, "toggled", (GCallback) toggled_cb, (void *) option);
     gtk_box_pack_start ((GtkBox *) hbox, toggle, true, true, 0);
 
-    GtkWidget * bbox = gtk_hbutton_box_new ();
+    GtkWidget * bbox = audgui_button_box_new (GTK_ORIENTATION_HORIZONTAL);
     gtk_button_box_set_layout ((GtkButtonBox *) bbox, GTK_BUTTONBOX_END);
     gtk_box_set_spacing ((GtkBox *) bbox, 6);
     gtk_box_pack_end ((GtkBox *) hbox, bbox, true, true, 0);

--- a/src/libaudgui/gtk-compat.cc
+++ b/src/libaudgui/gtk-compat.cc
@@ -1,0 +1,128 @@
+/*
+ * gtk-compat.cc
+ * Copyright 2022 Thomas Lange
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the documentation
+ *    provided with the distribution.
+ *
+ * This software is provided "as is" and without any warranty, express or
+ * implied. In no event shall the authors be liable for any damages arising from
+ * the use of this software.
+ */
+
+#include <gtk/gtk.h>
+
+EXPORT GtkWidget * audgui_box_new (GtkOrientation orientation, int spacing)
+{
+#ifdef USE_GTK3
+    return gtk_box_new (orientation, spacing);
+#else
+    return gtk_widget_new (orientation == GTK_ORIENTATION_HORIZONTAL
+                               ? GTK_TYPE_HBOX
+                               : GTK_TYPE_VBOX,
+                           "spacing", spacing,
+                           nullptr);
+#endif
+}
+
+EXPORT GtkWidget * audgui_button_box_new (GtkOrientation orientation)
+{
+#ifdef USE_GTK3
+    return gtk_button_box_new (orientation);
+#else
+    return gtk_widget_new (orientation == GTK_ORIENTATION_HORIZONTAL
+                               ? GTK_TYPE_HBUTTON_BOX
+                               : GTK_TYPE_VBUTTON_BOX,
+                           nullptr);
+#endif
+}
+
+EXPORT GtkWidget * audgui_paned_new (GtkOrientation orientation)
+{
+#ifdef USE_GTK3
+    return gtk_paned_new (orientation);
+#else
+    return gtk_widget_new (orientation == GTK_ORIENTATION_HORIZONTAL
+                               ? GTK_TYPE_HPANED
+                               : GTK_TYPE_VPANED,
+                           nullptr);
+#endif
+}
+
+EXPORT GtkWidget * audgui_scale_new (GtkOrientation orientation,
+                                     GtkAdjustment * adjustment)
+{
+#ifdef USE_GTK3
+    return gtk_scale_new (orientation, adjustment);
+#else
+    return gtk_widget_new (orientation == GTK_ORIENTATION_HORIZONTAL
+                               ? GTK_TYPE_HSCALE
+                               : GTK_TYPE_VSCALE,
+                           "adjustment", adjustment,
+                           nullptr);
+#endif
+}
+
+EXPORT GtkWidget * audgui_separator_new (GtkOrientation orientation)
+{
+#ifdef USE_GTK3
+    return gtk_separator_new (orientation);
+#else
+    return gtk_widget_new (orientation == GTK_ORIENTATION_HORIZONTAL
+                               ? GTK_TYPE_HSEPARATOR
+                               : GTK_TYPE_VSEPARATOR,
+                           nullptr);
+#endif
+}
+
+EXPORT GtkAdjustment * audgui_tree_view_get_hadjustment (GtkWidget * tree_view)
+{
+#ifdef USE_GTK3
+    return gtk_scrollable_get_hadjustment ((GtkScrollable *) tree_view);
+#else
+    return gtk_tree_view_get_hadjustment ((GtkTreeView *) tree_view);
+#endif
+}
+
+EXPORT GtkAdjustment * audgui_tree_view_get_vadjustment (GtkWidget * tree_view)
+{
+#ifdef USE_GTK3
+    return gtk_scrollable_get_vadjustment ((GtkScrollable *) tree_view);
+#else
+    return gtk_tree_view_get_vadjustment ((GtkTreeView *) tree_view);
+#endif
+}
+
+EXPORT GtkWidget * audgui_grid_new ()
+{
+#ifdef USE_GTK3
+    return gtk_grid_new ();
+#else
+    return gtk_table_new (1, 1, false);
+#endif
+}
+
+EXPORT void audgui_grid_set_row_spacing (GtkWidget * grid, unsigned int spacing)
+{
+#ifdef USE_GTK3
+    gtk_grid_set_row_spacing ((GtkGrid *) grid, spacing);
+#else
+    gtk_table_set_row_spacings ((GtkTable *) grid, spacing);
+#endif
+}
+
+EXPORT void audgui_grid_set_column_spacing (GtkWidget * grid, unsigned int spacing)
+{
+#ifdef USE_GTK3
+    gtk_grid_set_column_spacing ((GtkGrid *) grid, spacing);
+#else
+    gtk_table_set_col_spacings ((GtkTable *) grid, spacing);
+#endif
+}

--- a/src/libaudgui/gtk-compat.h
+++ b/src/libaudgui/gtk-compat.h
@@ -1,0 +1,47 @@
+/*
+ * gtk-compat.h
+ * Copyright 2022 Thomas Lange
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the documentation
+ *    provided with the distribution.
+ *
+ * This software is provided "as is" and without any warranty, express or
+ * implied. In no event shall the authors be liable for any damages arising from
+ * the use of this software.
+ */
+
+#ifndef AUDGUI_GTK_COMPAT_H
+#define AUDGUI_GTK_COMPAT_H
+
+#include <gtk/gtk.h>
+
+#ifdef USE_GTK3
+  #define AUDGUI_DRAW_SIGNAL "draw"
+#else
+  #define AUDGUI_DRAW_SIGNAL "expose-event"
+#endif
+
+#define audgui_hbox_new(spacing) audgui_box_new (GTK_ORIENTATION_HORIZONTAL, spacing)
+#define audgui_vbox_new(spacing) audgui_box_new (GTK_ORIENTATION_VERTICAL, spacing)
+
+GtkWidget * audgui_box_new (GtkOrientation orientation, int spacing);
+GtkWidget * audgui_button_box_new (GtkOrientation orientation);
+GtkWidget * audgui_paned_new (GtkOrientation orientation);
+GtkWidget * audgui_scale_new (GtkOrientation orientation, GtkAdjustment * adjustment);
+GtkWidget * audgui_separator_new (GtkOrientation orientation);
+
+GtkAdjustment * audgui_tree_view_get_hadjustment (GtkWidget * tree_view);
+GtkAdjustment * audgui_tree_view_get_vadjustment (GtkWidget * tree_view);
+
+GtkWidget * audgui_grid_new ();
+void audgui_grid_set_row_spacing (GtkWidget * grid, unsigned int spacing);
+void audgui_grid_set_column_spacing (GtkWidget * grid, unsigned int spacing);
+
+#endif /* AUDGUI_GTK_COMPAT_H */

--- a/src/libaudgui/jump-to-track.cc
+++ b/src/libaudgui/jump-to-track.cc
@@ -25,6 +25,7 @@
 #include <libaudcore/playlist.h>
 #include <libaudcore/runtime.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -245,7 +246,7 @@ static GtkWidget * create_window ()
     gtk_container_set_border_width ((GtkContainer *) jump_to_track_win, 10);
     gtk_window_set_default_size ((GtkWindow *) jump_to_track_win, 6 * dpi, 5 * dpi);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_add ((GtkContainer *) jump_to_track_win, vbox);
 
     treeview = audgui_list_new (& callbacks, nullptr, 0);
@@ -258,7 +259,7 @@ static GtkWidget * create_window ()
      "changed", (GCallback) selection_changed, nullptr);
     g_signal_connect (treeview, "row-activated", (GCallback) do_jump, nullptr);
 
-    GtkWidget * hbox = gtk_hbox_new (false, 6);
+    GtkWidget * hbox = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, hbox, false, false, 3);
 
     /* filter box */
@@ -282,17 +283,22 @@ static GtkWidget * create_window ()
     gtk_scrolled_window_set_shadow_type ((GtkScrolledWindow *) scrollwin, GTK_SHADOW_IN);
     gtk_box_pack_start ((GtkBox *) vbox, scrollwin, true, true, 0);
 
-    GtkWidget * hbox2 = gtk_hbox_new (false, 0);
+    GtkWidget * hbox2 = audgui_hbox_new (0);
     gtk_box_pack_end ((GtkBox *) vbox, hbox2, false, false, 0);
 
-    GtkWidget * bbox = gtk_hbutton_box_new ();
+    GtkWidget * bbox = audgui_button_box_new (GTK_ORIENTATION_HORIZONTAL);
     gtk_button_box_set_layout ((GtkButtonBox *) bbox, GTK_BUTTONBOX_END);
     gtk_box_set_spacing ((GtkBox *) bbox, 6);
 
+#ifdef USE_GTK3
+    gtk_widget_set_margin_start (bbox, 6);
+    gtk_box_pack_end ((GtkBox *) hbox2, bbox, true, true, 0);
+#else
     GtkWidget * alignment = gtk_alignment_new (0.5, 0.5, 1, 1);
     gtk_alignment_set_padding ((GtkAlignment *) alignment, 0, 0, 6, 0);
     gtk_container_add ((GtkContainer *) alignment, bbox);
     gtk_box_pack_end ((GtkBox *) hbox2, alignment, true, true, 0);
+#endif
 
     /* close dialog toggle */
     GtkWidget * toggle = gtk_check_button_new_with_mnemonic (_("C_lose on jump"));

--- a/src/libaudgui/list.cc
+++ b/src/libaudgui/list.cc
@@ -23,6 +23,7 @@
 #include <libaudcore/hook.h>
 #include <libaudcore/objects.h>
 
+#include "gtk-compat.h"
 #include "libaudgui-gtk.h"
 #include "list.h"
 
@@ -389,7 +390,7 @@ static void autoscroll (void * widget)
     ListModel * model = (ListModel *) gtk_tree_view_get_model
      ((GtkTreeView *) widget);
 
-    GtkAdjustment * adj = gtk_tree_view_get_vadjustment ((GtkTreeView *) widget);
+    GtkAdjustment * adj = audgui_tree_view_get_vadjustment ((GtkWidget *) widget);
     g_return_if_fail (adj);
 
     int pos, end;
@@ -406,7 +407,7 @@ static void autoscroll (void * widget)
 
 static void start_autoscroll (ListModel * model, GtkWidget * widget, int speed)
 {
-    GtkAdjustment * adj = gtk_tree_view_get_vadjustment ((GtkTreeView *) widget);
+    GtkAdjustment * adj = audgui_tree_view_get_vadjustment (widget);
     g_return_if_fail (adj);
 
     int pos, end;

--- a/src/libaudgui/menu.cc
+++ b/src/libaudgui/menu.cc
@@ -23,6 +23,10 @@
 #include <libaudcore/i18n.h>
 #include <libaudcore/runtime.h>
 
+/* we still use GtkImageMenuItem until there is a good alternative */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 static GtkWidget * image_menu_item_new (const char * text, const char * icon)
 {
     GtkWidget * widget = gtk_image_menu_item_new_with_mnemonic (text);
@@ -35,6 +39,8 @@ static GtkWidget * image_menu_item_new (const char * text, const char * icon)
 
     return widget;
 }
+
+#pragma GCC diagnostic pop
 
 static void toggled_cb (GtkCheckMenuItem * check, const AudguiMenuItem * item)
 {

--- a/src/libaudgui/meson.build
+++ b/src/libaudgui/meson.build
@@ -4,6 +4,7 @@ libaudgui_sources = [
   'eq-preset.cc',
   'equalizer.cc',
   'file-opener.cc',
+  'gtk-compat.cc',
   'infopopup.cc',
   'infowin.cc',
   'init.cc',
@@ -30,6 +31,7 @@ libaudgui_sources = [
 
 
 libaudgui_headers = [
+  'gtk-compat.h',
   'libaudgui.h',
   'libaudgui-gtk.h',
   'list.h',

--- a/src/libaudgui/plugin-prefs.cc
+++ b/src/libaudgui/plugin-prefs.cc
@@ -23,6 +23,7 @@
 #include <libaudcore/plugins.h>
 #include <libaudcore/preferences.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -168,7 +169,7 @@ EXPORT void audgui_show_plugin_prefs (PluginHandle * plugin)
     }
 
     GtkWidget * content = gtk_dialog_get_content_area ((GtkDialog *) window);
-    GtkWidget * box = gtk_vbox_new (false, 0);
+    GtkWidget * box = audgui_vbox_new (0);
     audgui_create_widgets_with_domain (box, p->widgets, header->info.domain);
     gtk_box_pack_start ((GtkBox *) content, box, true, true, 0);
 

--- a/src/libaudgui/plugin-view.cc
+++ b/src/libaudgui/plugin-view.cc
@@ -23,6 +23,7 @@
 #include <libaudcore/plugin.h>
 #include <libaudcore/plugins.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -214,7 +215,7 @@ static void button_destroy (GtkWidget * b)
 
 GtkWidget * plugin_view_new (PluginType type)
 {
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_set_border_width ((GtkContainer *) vbox, 6);
 
     GtkWidget * scrolled = gtk_scrolled_window_new (nullptr, nullptr);
@@ -229,7 +230,7 @@ GtkWidget * plugin_view_new (PluginType type)
     g_signal_connect (tree, "realize", (GCallback) list_fill, aud::to_ptr (type));
     g_signal_connect (tree, "destroy", (GCallback) list_destroy, nullptr);
 
-    GtkWidget * hbox = gtk_hbox_new (false, 6);
+    GtkWidget * hbox = audgui_hbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, hbox, false, false, 0);
 
     GtkWidget * config = audgui_button_new (_("_Settings"), "preferences-system", do_config, tree);

--- a/src/libaudgui/status.cc
+++ b/src/libaudgui/status.cc
@@ -22,6 +22,7 @@
 #include <libaudcore/hook.h>
 #include <libaudcore/i18n.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui-gtk.h"
 
@@ -37,7 +38,7 @@ static void create_progress_window ()
     gtk_window_set_resizable ((GtkWindow *) progress_window, false);
     gtk_container_set_border_width ((GtkContainer *) progress_window, 6);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_container_add ((GtkContainer *) progress_window, vbox);
 
     progress_label = gtk_label_new (nullptr);

--- a/src/libaudgui/url-opener.cc
+++ b/src/libaudgui/url-opener.cc
@@ -24,6 +24,7 @@
 #include <libaudcore/preferences.h>
 #include <libaudcore/runtime.h>
 
+#include "gtk-compat.h"
 #include "internal.h"
 #include "libaudgui.h"
 #include "libaudgui-gtk.h"
@@ -86,14 +87,14 @@ static GtkWidget * create_url_opener (bool open)
 
     g_object_set_data ((GObject *) entry, "open", GINT_TO_POINTER (open));
 
-    GtkWidget * hbox = gtk_hbox_new (false, 6);
+    GtkWidget * hbox = audgui_hbox_new (6);
     audgui_create_widgets (hbox, widgets);
 
     GtkWidget * clear_button = audgui_button_new (_("C_lear history"),
      "edit-clear", clear_cb, combo);
     gtk_box_pack_end ((GtkBox *) hbox, clear_button, false, false, 0);
 
-    GtkWidget * vbox = gtk_vbox_new (false, 6);
+    GtkWidget * vbox = audgui_vbox_new (6);
     gtk_box_pack_start ((GtkBox *) vbox, combo, false, false, 0);
     gtk_box_pack_start ((GtkBox *) vbox, hbox, false, false, 0);
 


### PR DESCRIPTION
- Add a slim compatibility layer (gtk-compat.h) which makes it pretty straightforward
  to support both GTK versions in one code base.

- GTK2 is still the default (requested by @jlindgren90).
  GTK3 can be enabled with "--enable-gtk3", or when using Meson with "-D gtk3=true".

- Require at least GTK 3.22 (released in 2016) to avoid specific GTK version checks
  and make use of recent APIs if possible.

- Since GTK2 is end of life upstream, modern distributions may have stopped to ship
  Audacious with GTK support. Now they can do that again with GTK3 and Qt combined
  or as separate packages.