### PR TITLE
Add Lyrics Tag support

### DIFF
--- a/src/libaudcore/tuple.cc
+++ b/src/libaudcore/tuple.cc
@@ -150,6 +150,7 @@ static const struct
     {"channels", Tuple::Int, -1},
     {"publisher", Tuple::String, -1},
     {"catalog-number", Tuple::String, -1},
+    {"lyrics", Tuple::String, -1},
 
     /* fallbacks */
     {nullptr, Tuple::String, -1},
@@ -193,6 +194,7 @@ static const FieldDictEntry field_dict[] = {
     {"gain-track-peak", Tuple::TrackPeak},
     {"genre", Tuple::Genre},
     {"length", Tuple::Length},
+    {"lyrics", Tuple::Lyrics},
     {"musicbrainz-id", Tuple::MusicBrainzID},
     {"performer", Tuple::Performer},
     {"publisher", Tuple::Publisher},

--- a/src/libaudcore/tuple.h
+++ b/src/libaudcore/tuple.h
@@ -108,6 +108,7 @@ public:
         Channels, /* Track channels count */
         Publisher,  /* Publisher (label) */
         CatalogNum, /* Catalog number */
+        Lyrics,  /* Lyrics from id3 tags. */
 
         n_fields
     };

--- a/src/libaudtag/id3/id3-common.cc
+++ b/src/libaudtag/id3/id3-common.cc
@@ -150,7 +150,7 @@ void id3_decode_genre (Tuple & tuple, const char * data, int size)
         tuple.set_str (Tuple::Genre, text);
 }
 
-void id3_decode_comment (Tuple & tuple, const char * data, int size)
+void id3_associate_memo (Tuple & tuple, Tuple::Field field, const char * data, int size)
 {
     if (size < 4)
         return;
@@ -162,11 +162,11 @@ void id3_decode_comment (Tuple & tuple, const char * data, int size)
     StringBuf type = id3_convert (data + 4, before_nul, data[0]);
     StringBuf value = id3_convert (data + 4 + after_nul, size - 4 - after_nul, data[0]);
 
-    AUDDBG ("Comment: lang = %.3s, type = %s, value = %s.\n", lang,
-     (const char *) type, (const char *) value);
+    AUDDBG ("Field %s: lang = %.3s, type = %s, value = %s.\n", Tuple::field_get_name(field),
+           lang, (const char *) type, (const char *) value);
 
     if (type && ! type[0] && value) /* blank type = actual comment */
-        tuple.set_str (Tuple::Comment, value);
+        tuple.set_str (field, value);
 }
 
 static bool decode_rva_block (const char * * _data, int * _size,

--- a/src/libaudtag/id3/id3-common.h
+++ b/src/libaudtag/id3/id3-common.h
@@ -27,7 +27,7 @@ void id3_associate_string (Tuple & tuple, Tuple::Field field, const char * data,
 void id3_associate_int (Tuple & tuple, Tuple::Field field, const char * data, int size);
 void id3_associate_length (Tuple & tuple, const char * data, int size);
 void id3_decode_genre (Tuple & tuple, const char * data, int size);
-void id3_decode_comment (Tuple & tuple, const char * data, int size);
+void id3_associate_memo (Tuple & tuple, Tuple::Field field, const char * data, int size);
 void id3_decode_rva (Tuple & tuple, const char * data, int size);
 void id3_decode_txxx (Tuple & tuple, const char * data, int size);
 

--- a/src/libaudtag/id3/id3v24.cc
+++ b/src/libaudtag/id3/id3v24.cc
@@ -668,16 +668,10 @@ bool ID3v24TagModule::write_tag (VFSFile & f, const Tuple & tuple)
     add_frameFromTupleStr (tuple, Tuple::Genre, ID3_GENRE, dict);
 
     String comment = tuple.get_str (Tuple::Comment);
-    if (comment && comment[0])
-    {
-        add_memo_frame(ID3_COMMENT, comment, dict);
-    }
+    add_memo_frame (ID3_COMMENT, comment, dict);
 
     String lyrics = tuple.get_str (Tuple::Lyrics);
-    if (lyrics && lyrics[0])
-    {
-        add_memo_frame (ID3_LYRICS, lyrics, dict);
-    }
+    add_memo_frame (ID3_LYRICS, lyrics, dict);
 
     /* location and size of non-tag data */
     int64_t mp3_offset = offset ? 0 : header_size + data_size + footer_size;


### PR DESCRIPTION
Why not to add Lyrics tag support? I was waiting for this feature for several years and decided to do it myself. I simply ported Fauxdacious library "libfauxdtag" to original audacious branch and It Worked!!!

There is also need to port Fauxdacious lyricwiki plugin to display lyrics.
Thank You!