### PR TITLE
Add a WM_WINDOW_ROLE property to toplevel X11 windows.

### DIFF
--- a/src/libaudgui/about.cc
+++ b/src/libaudgui/about.cc
@@ -71,6 +71,7 @@ static GtkWidget * create_about_window ()
 
     GtkWidget * about_window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title ((GtkWindow *) about_window, _("About Audacious"));
+    gtk_window_set_role ((GtkWindow *) about_window, "about");
     gtk_window_set_resizable ((GtkWindow *) about_window, false);
     gtk_container_set_border_width ((GtkContainer *) about_window, 3);
 

--- a/src/libaudgui/eq-preset.cc
+++ b/src/libaudgui/eq-preset.cc
@@ -281,6 +281,7 @@ static GtkWidget * create_eq_preset_window ()
 
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title ((GtkWindow *) window, _("Equalizer Presets"));
+    gtk_window_set_role ((GtkWindow *) window, "equalizer-presets");
     gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_default_size ((GtkWindow *) window, 3 * dpi, 3 * dpi);
     audgui_destroy_on_escape (window);

--- a/src/libaudgui/equalizer.cc
+++ b/src/libaudgui/equalizer.cc
@@ -131,6 +131,7 @@ static GtkWidget * create_window ()
 
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title ((GtkWindow *) window, _("Equalizer"));
+    gtk_window_set_role ((GtkWindow *) window, "equalizer");
     gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_resizable ((GtkWindow *) window, false);
     gtk_container_set_border_width ((GtkContainer *) window, 6);

--- a/src/libaudgui/file-opener.cc
+++ b/src/libaudgui/file-opener.cc
@@ -97,7 +97,7 @@ static GtkWidget * create_filebrowser (gboolean open)
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_title ((GtkWindow *) window, window_title);
-    gtk_window_set_role ((GtkWindow *) window, "filedialog");
+    gtk_window_set_role ((GtkWindow *) window, "file-dialog");
     gtk_window_set_default_size ((GtkWindow *) window, 7 * dpi, 5 * dpi);
 
 #ifndef USE_GTK3

--- a/src/libaudgui/file-opener.cc
+++ b/src/libaudgui/file-opener.cc
@@ -97,6 +97,7 @@ static GtkWidget * create_filebrowser (gboolean open)
     GtkWidget * window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_window_set_type_hint ((GtkWindow *) window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_title ((GtkWindow *) window, window_title);
+    gtk_window_set_role ((GtkWindow *) window, "filedialog");
     gtk_window_set_default_size ((GtkWindow *) window, 7 * dpi, 5 * dpi);
 
 #ifndef USE_GTK3

--- a/src/libaudgui/infopopup.cc
+++ b/src/libaudgui/infopopup.cc
@@ -183,6 +183,7 @@ static GtkWidget * infopopup_create ()
     GtkWidget * infopopup = gtk_window_new (GTK_WINDOW_POPUP);
     gtk_window_set_type_hint ((GtkWindow *) infopopup, GDK_WINDOW_TYPE_HINT_TOOLTIP);
     gtk_window_set_decorated ((GtkWindow *) infopopup, false);
+    gtk_window_set_role ((GtkWindow *) infopopup, "infopopup");
     gtk_container_set_border_width ((GtkContainer *) infopopup, 4);
 
     GtkWidget * hbox = audgui_hbox_new (6);

--- a/src/libaudgui/infowin.cc
+++ b/src/libaudgui/infowin.cc
@@ -331,6 +331,7 @@ static void create_infowin ()
     infowin = gtk_window_new (GTK_WINDOW_TOPLEVEL);
     gtk_container_set_border_width ((GtkContainer *) infowin, 6);
     gtk_window_set_title ((GtkWindow *) infowin, _("Song Info"));
+    gtk_window_set_role ((GtkWindow *) infowin, "song-info");
     gtk_window_set_type_hint ((GtkWindow *) infowin,
      GDK_WINDOW_TYPE_HINT_DIALOG);
 

--- a/src/libaudgui/jump-to-track.cc
+++ b/src/libaudgui/jump-to-track.cc
@@ -239,6 +239,7 @@ static GtkWidget * create_window ()
     gtk_window_set_type_hint ((GtkWindow *) jump_to_track_win, GDK_WINDOW_TYPE_HINT_DIALOG);
 
     gtk_window_set_title ((GtkWindow *) jump_to_track_win, _("Jump to Song"));
+    gtk_window_set_role ((GtkWindow *) jump_to_track_win, "jump-to-song");
 
     g_signal_connect (jump_to_track_win, "key_press_event", (GCallback) keypress_cb, nullptr);
     g_signal_connect (jump_to_track_win, "destroy", (GCallback) destroy_cb, nullptr);

--- a/src/libaudgui/plugin-prefs.cc
+++ b/src/libaudgui/plugin-prefs.cc
@@ -154,6 +154,7 @@ EXPORT void audgui_show_plugin_prefs (PluginHandle * plugin)
 
     GtkWidget * window = gtk_dialog_new ();
     gtk_window_set_title ((GtkWindow *) window, str_printf (_("%s Settings"), name));
+    gtk_window_set_role ((GtkWindow *) window, "plugin-settings");
 
     if (p->apply)
     {

--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -885,6 +885,7 @@ static void create_prefs_window ()
     gtk_window_set_type_hint ((GtkWindow *) prefswin, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_container_set_border_width ((GtkContainer *) prefswin, 12);
     gtk_window_set_title ((GtkWindow *) prefswin, _("Audacious Settings"));
+    gtk_window_set_role ((GtkWindow *) prefswin, "settings");
 
     GtkWidget * vbox = audgui_vbox_new (0);
     gtk_container_add ((GtkContainer *) prefswin, vbox);

--- a/src/libaudgui/queue-manager.cc
+++ b/src/libaudgui/queue-manager.cc
@@ -173,6 +173,7 @@ static GtkWidget * create_queue_manager ()
 
     GtkWidget * qm_win = gtk_dialog_new ();
     gtk_window_set_title ((GtkWindow *) qm_win, _("Queue Manager"));
+    gtk_window_set_role ((GtkWindow *) qm_win, "queue-manager");
     gtk_window_set_default_size ((GtkWindow *) qm_win, 3 * dpi, 2 * dpi);
 
     GtkWidget * vbox = gtk_dialog_get_content_area ((GtkDialog *) qm_win);

--- a/src/libaudgui/status.cc
+++ b/src/libaudgui/status.cc
@@ -36,6 +36,7 @@ static void create_progress_window ()
     gtk_window_set_type_hint ((GtkWindow *) progress_window, GDK_WINDOW_TYPE_HINT_DIALOG);
     gtk_window_set_title ((GtkWindow *) progress_window, _("Working ..."));
     gtk_window_set_resizable ((GtkWindow *) progress_window, false);
+    gtk_window_set_role ((GtkWindow *) progress_window, "progress");
     gtk_container_set_border_width ((GtkContainer *) progress_window, 6);
 
     GtkWidget * vbox = audgui_vbox_new (6);

--- a/src/libaudgui/util.cc
+++ b/src/libaudgui/util.cc
@@ -284,6 +284,7 @@ EXPORT GtkWidget * audgui_dialog_new (GtkMessageType type, const char * title,
     GtkWidget * dialog = gtk_message_dialog_new (nullptr, (GtkDialogFlags) 0, type,
      GTK_BUTTONS_NONE, "%s", text);
     gtk_window_set_title ((GtkWindow *) dialog, title);
+    gtk_window_set_role ((GtkWindow *) dialog, "message");
 
     GtkWidget * box = gtk_message_dialog_get_message_area ((GtkMessageDialog *) dialog);
     gtk_container_foreach ((GtkContainer *) box, set_label_wrap, nullptr);

--- a/src/libaudqt/about-qt.cc
+++ b/src/libaudqt/about-qt.cc
@@ -62,6 +62,7 @@ static QDialog * buildAboutWindow()
 
     auto window = new QDialog;
     window->setWindowTitle(_("About Audacious"));
+    window->setWindowRole("about");
 
     auto logo = new QLabel(window);
     int logo_size = audqt::to_native_dpi(400);

--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -314,6 +314,7 @@ EXPORT void simple_message(const char * title, const char * text,
     msgbox->button(QMessageBox::Close)->setText(translate_str(N_("_Close")));
     msgbox->setAttribute(Qt::WA_DeleteOnClose);
     msgbox->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    msgbox->setWindowRole("message");
     msgbox->show();
 }
 

--- a/src/libaudqt/colorbutton.cc
+++ b/src/libaudqt/colorbutton.cc
@@ -34,6 +34,7 @@ ColorButton::ColorButton(QWidget * parent) : QPushButton(parent)
         {
             dialog = new QColorDialog(m_color, this);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
+            dialog->setWindowRole("color-dialog");
             connect(dialog, &QColorDialog::colorSelected, this,
                     &ColorButton::setColor);
         }

--- a/src/libaudqt/eq-preset-qt.cc
+++ b/src/libaudqt/eq-preset-qt.cc
@@ -260,7 +260,7 @@ static void show_import_dialog(QWidget * parent, PresetView * view,
     dialog->setFileMode(QFileDialog::ExistingFile);
     dialog->setLabelText(QFileDialog::Accept, _("Load"));
     dialog->setNameFilter(_(name_filter));
-    dialog->setWindowRole("filedialog");
+    dialog->setWindowRole("file-dialog");
 
     auto do_import = [dialog, view, revert_btn]() {
         auto urls = dialog->selectedUrls();
@@ -298,7 +298,7 @@ static void show_export_dialog(QWidget * parent, const EqualizerPreset & preset)
     dialog->setFileMode(QFileDialog::AnyFile);
     dialog->setLabelText(QFileDialog::Accept, _("Save"));
     dialog->setNameFilter(_(name_filter));
-    dialog->setWindowRole("filedialog");
+    dialog->setWindowRole("file-dialog");
 
     /* TODO: replace other illegal characters on Win32 */
     auto safe =

--- a/src/libaudqt/eq-preset-qt.cc
+++ b/src/libaudqt/eq-preset-qt.cc
@@ -260,6 +260,7 @@ static void show_import_dialog(QWidget * parent, PresetView * view,
     dialog->setFileMode(QFileDialog::ExistingFile);
     dialog->setLabelText(QFileDialog::Accept, _("Load"));
     dialog->setNameFilter(_(name_filter));
+    dialog->setWindowRole("filedialog");
 
     auto do_import = [dialog, view, revert_btn]() {
         auto urls = dialog->selectedUrls();
@@ -297,6 +298,7 @@ static void show_export_dialog(QWidget * parent, const EqualizerPreset & preset)
     dialog->setFileMode(QFileDialog::AnyFile);
     dialog->setLabelText(QFileDialog::Accept, _("Save"));
     dialog->setNameFilter(_(name_filter));
+    dialog->setWindowRole("filedialog");
 
     /* TODO: replace other illegal characters on Win32 */
     auto safe =

--- a/src/libaudqt/file-entry.cc
+++ b/src/libaudqt/file-entry.cc
@@ -61,7 +61,7 @@ QFileDialog * FileEntry::create_dialog()
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setFileMode(m_file_mode);
     dialog->setAcceptMode(m_accept_mode);
-    dialog->setWindowRole("filedialog");
+    dialog->setWindowRole("file-dialog");
 
     String uri = file_entry_get_uri(this);
     if (uri)

--- a/src/libaudqt/file-entry.cc
+++ b/src/libaudqt/file-entry.cc
@@ -61,6 +61,7 @@ QFileDialog * FileEntry::create_dialog()
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setFileMode(m_file_mode);
     dialog->setAcceptMode(m_accept_mode);
+    dialog->setWindowRole("filedialog");
 
     String uri = file_entry_get_uri(this);
     if (uri)

--- a/src/libaudqt/fileopener.cc
+++ b/src/libaudqt/fileopener.cc
@@ -122,6 +122,7 @@ EXPORT void fileopener_show(FileMode mode)
             dialog->setOption(QFileDialog::ShowDirsOnly);
         dialog->setLabelText(QFileDialog::Accept, _(labels[mode]));
         dialog->setLabelText(QFileDialog::Reject, _("Cancel"));
+        dialog->setWindowRole("filedialog");
 
         auto playlist = Playlist::active_playlist();
 

--- a/src/libaudqt/fileopener.cc
+++ b/src/libaudqt/fileopener.cc
@@ -122,7 +122,7 @@ EXPORT void fileopener_show(FileMode mode)
             dialog->setOption(QFileDialog::ShowDirsOnly);
         dialog->setLabelText(QFileDialog::Accept, _(labels[mode]));
         dialog->setLabelText(QFileDialog::Reject, _("Cancel"));
-        dialog->setWindowRole("filedialog");
+        dialog->setWindowRole("file-dialog");
 
         auto playlist = Playlist::active_playlist();
 

--- a/src/libaudqt/infowin-qt.cc
+++ b/src/libaudqt/infowin-qt.cc
@@ -62,6 +62,7 @@ private:
 InfoWindow::InfoWindow(QWidget * parent) : QDialog(parent)
 {
     setWindowTitle(_("Song Info"));
+    setWindowRole("song-info");
     setContentsMargins(margins.TwoPt);
 
     m_uri_label.setFixedWidth(2 * audqt::sizes.OneInch);

--- a/src/libaudqt/log-inspector.cc
+++ b/src/libaudqt/log-inspector.cc
@@ -209,6 +209,7 @@ private:
 LogEntryInspector::LogEntryInspector(QWidget * parent) : QDialog(parent)
 {
     setWindowTitle(_("Log Inspector"));
+    setWindowRole("log-inspector");
     setContentsMargins(margins.TwoPt);
 
     auto view = new QTreeView(this);

--- a/src/libaudqt/playlist-management.cc
+++ b/src/libaudqt/playlist-management.cc
@@ -36,6 +36,7 @@ static QDialog * buildRenameDialog(Playlist playlist)
     auto dialog = new QInputDialog;
     dialog->setInputMode(QInputDialog::TextInput);
     dialog->setWindowTitle(_("Rename Playlist"));
+    dialog->setWindowRole("rename-playlist");
     dialog->setLabelText(_("What would you like to call this playlist?"));
     dialog->setOkButtonText(translate_str(N_("_Rename")));
     dialog->setCancelButtonText(translate_str(N_("_Cancel")));
@@ -60,6 +61,7 @@ static QDialog * buildDeleteDialog(Playlist playlist)
 
     dialog->setIcon(QMessageBox::Question);
     dialog->setWindowTitle(_("Remove Playlist"));
+    dialog->setWindowRole("remove-playlist");
     dialog->setText(
         (const char *)str_printf(_("Do you want to permanently remove “%s”?"),
                                  (const char *)playlist.get_title()));

--- a/src/libaudqt/prefs-plugin.cc
+++ b/src/libaudqt/prefs-plugin.cc
@@ -124,6 +124,7 @@ EXPORT void plugin_prefs(PluginHandle * ph)
         name = dgettext(header->info.domain, name);
 
     cw->root->setWindowTitle((const char *)str_printf(_("%s Settings"), name));
+    cw->root->setWindowRole("settings");
 
     auto vbox = make_vbox(cw->root, sizes.TwoPt);
     prefs_populate(vbox, p->widgets, header->info.domain);

--- a/src/libaudqt/prefs-plugin.cc
+++ b/src/libaudqt/prefs-plugin.cc
@@ -124,7 +124,7 @@ EXPORT void plugin_prefs(PluginHandle * ph)
         name = dgettext(header->info.domain, name);
 
     cw->root->setWindowTitle((const char *)str_printf(_("%s Settings"), name));
-    cw->root->setWindowRole("settings");
+    cw->root->setWindowRole("plugin-settings");
 
     auto vbox = make_vbox(cw->root, sizes.TwoPt);
     prefs_populate(vbox, p->widgets, header->info.domain);

--- a/src/libaudqt/prefs-window-qt.cc
+++ b/src/libaudqt/prefs-window-qt.cc
@@ -645,6 +645,7 @@ PrefsWindow::PrefsWindow()
 
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(_("Audacious Settings"));
+    setWindowRole("settings");
     setContentsMargins(0, 0, 0, 0);
 
     output_config_button->setAutoDefault(false);

--- a/src/libaudqt/queue-manager-qt.cc
+++ b/src/libaudqt/queue-manager-qt.cc
@@ -206,6 +206,7 @@ void QueueManager::keyPressEvent(QKeyEvent * event)
 
 QueueManager::QueueManager(QWidget * parent) : QWidget(parent)
 {
+    setWindowRole("queue-manager");
     m_btn_unqueue.setText(translate_str(N_("_Unqueue")));
 
     connect(&m_btn_unqueue, &QAbstractButton::clicked, this,

--- a/src/libaudqt/song-window-qt.cc
+++ b/src/libaudqt/song-window-qt.cc
@@ -292,6 +292,7 @@ SongsWindow::SongsWindow()
 
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(_("Jump to Song"));
+    setWindowRole("jump-to-song");
     setContentsMargins(0, 0, 0, 0);
 
     auto vbox_parent = make_vbox(this);

--- a/src/libaudqt/url-opener-qt.cc
+++ b/src/libaudqt/url-opener-qt.cc
@@ -57,6 +57,7 @@ static QDialog * buildUrlDialog(bool open)
 
     auto dialog = new QDialog;
     dialog->setWindowTitle(title);
+    dialog->setWindowRole("history");
     dialog->setContentsMargins(margins.EightPt);
 
     auto label = new QLabel(_("Enter URL:"), dialog);

--- a/src/libaudqt/url-opener-qt.cc
+++ b/src/libaudqt/url-opener-qt.cc
@@ -57,7 +57,7 @@ static QDialog * buildUrlDialog(bool open)
 
     auto dialog = new QDialog;
     dialog->setWindowTitle(title);
-    dialog->setWindowRole("history");
+    dialog->setWindowRole("url-dialog");
     dialog->setContentsMargins(margins.EightPt);
 
     auto label = new QLabel(_("Enter URL:"), dialog);


### PR DESCRIPTION
With window managers like icewm and i3 users can configure window specific settings. For this to work toplevel windows must be distinguishable by a X11 property. Because Audacious uses the same WM_CLASS property for all its windows, the WM_WINDOW_ROLE property must be set. However, Audacious currently does not set this property. It is defined in the ICCCM manual for X11 clients. This patch sets this property on Gtk and Qt toplevel windows using designated library calls.