### PR TITLE
Add missing enum value.

### DIFF
--- a/src/libaudcore/vfs.h
+++ b/src/libaudcore/vfs.h
@@ -51,6 +51,7 @@ enum VFSReadOptions
 
 enum VFSSeekType
 {
+    VFS_SEEK_INVALID = -1,
     VFS_SEEK_SET = 0,
     VFS_SEEK_CUR = 1,
     VFS_SEEK_END = 2
@@ -75,7 +76,7 @@ constexpr VFSSeekType to_vfs_seek_type(int whence)
                ? VFS_SEEK_SET
                : (whence == SEEK_CUR)
                      ? VFS_SEEK_CUR
-                     : (whence == SEEK_END) ? VFS_SEEK_END : (VFSSeekType)-1;
+                     : (whence == SEEK_END) ? VFS_SEEK_END : VFS_SEEK_INVALID;
 }
 
 #endif // WANT_VFS_STDIO_COMPAT


### PR DESCRIPTION
New versions of the clang compiler have strict checks for enum values.

The value "-1" is returned as a last resort from to_vfs_seek_type() as a VFSSeekType.

I added the value with a name that makes sense for such usage.

For context:

This is necessary to make audacious compile on latest FreeBSD head (future FreeBSD 14.0) which includes clang version 16.

I already added thsi as a local patch to the FreeBSD ports tree: https://github.com/freebsd/freebsd-ports/commit/72610ecbe5d5b8ea93f4ebcf35148f61cddd7a23