### PR TITLE
CYGWIN: meson: support correct file extension for plugins.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ endif
 
 have_darwin = host_machine.system() == 'darwin'
 have_windows = host_machine.system() == 'windows'
+have_cygwin = host_machine.system() == 'cygwin'
 
 
 cc = meson.get_compiler('c')
@@ -98,7 +99,7 @@ endif
 
 
 # XXX - investigate to see if we can do better
-if have_windows
+if have_windows or have_cygwin
   conf.set_quoted('PLUGIN_SUFFIX', '.dll')
 elif have_darwin
   conf.set_quoted('PLUGIN_SUFFIX', '.dylib')


### PR DESCRIPTION
CYGWIN uses shared libraries with `.dll` extension like Windows.
This patch fixes `meson.build` for setting `PLUGIN_SUFFIX` to the correct value for this platform.