### PR TITLE
CI: Fix macOS build by installing python setuptools

### DIFF
--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -39,6 +39,13 @@ case "$os" in
     else
       brew install qt@5 automake
     fi
+
+    # Install Python setuptools for the distutils module which is still
+    # required by gdbus-codegen and no longer shipped with Python >= 3.12.
+    #
+    # - https://peps.python.org/pep-0632
+    # - https://github.com/python/cpython/issues/95299
+    python3 -m pip install setuptools
     ;;
 
   windows*)

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout audacious
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies


### PR DESCRIPTION
The macOS runner uses Python 3.12 meanwhile which removed
the distutils package, still required by gdbus-codegen.

See also: https://docs.python.org/3/whatsnew/3.12.html