### PR TITLE
CI: Use 64-bit for Windows and disable autotools build

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -20,8 +20,12 @@ runs:
     - uses: msys2/setup-msys2@v2
       if: startsWith(inputs.os, 'windows')
       with:
-        msystem: MINGW32
+        msystem: MINGW64
         update: true
         install: >-
-          mingw-w64-i686-autotools mingw-w64-i686-gcc mingw-w64-i686-gtk2
-          mingw-w64-i686-meson mingw-w64-i686-pkg-config mingw-w64-i686-qt5-base
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-gtk2
+          mingw-w64-x86_64-meson
+          mingw-w64-x86_64-pkg-config
+          mingw-w64-x86_64-qt5-base

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-12', 'windows-2022']
         build-system: ['autotools', 'meson']
+        exclude:
+          - os: 'windows-2022'
+            build-system: 'autotools'
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
See also: https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages