### PR TITLE
meson: Change default Qt version to 6

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -28,4 +28,4 @@ runs:
           mingw-w64-x86_64-gtk2
           mingw-w64-x86_64-meson
           mingw-w64-x86_64-pkg-config
-          mingw-w64-x86_64-qt5-base
+          mingw-w64-x86_64-qt6-base

--- a/.github/actions/install-dependencies/install-dependencies.sh
+++ b/.github/actions/install-dependencies/install-dependencies.sh
@@ -4,7 +4,7 @@
 #
 # ubuntu-20.04:      Qt 5 + GTK2
 # ubuntu-22.04:      Qt 5 + GTK3
-# Windows:           Qt 5 + GTK2
+# Windows:           Qt 6 + GTK2
 # macOS (Autotools): Qt 5 - GTK
 # macOS (Meson):     Qt 6 - GTK
 

--- a/.github/actions/run-action/run-action.sh
+++ b/.github/actions/run-action/run-action.sh
@@ -4,7 +4,7 @@
 #
 # ubuntu-20.04:      Qt 5 + GTK2
 # ubuntu-22.04:      Qt 5 + GTK3
-# Windows:           Qt 5 + GTK2
+# Windows:           Qt 6 + GTK2
 # macOS (Autotools): Qt 5 - GTK
 # macOS (Meson):     Qt 6 - GTK
 
@@ -28,9 +28,9 @@ fi
 case "$action" in
   configure)
     case "$os" in
-      ubuntu-20.04 | windows*)
+      ubuntu-20.04)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build
+          meson setup build -D qt5=true
         else
           ./autogen.sh && ./configure
         fi
@@ -38,7 +38,7 @@ case "$action" in
 
       ubuntu*)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build -D gtk3=true
+          meson setup build -D qt5=true -D gtk3=true
         else
           ./autogen.sh && ./configure --enable-gtk3
         fi
@@ -46,11 +46,19 @@ case "$action" in
 
       macos*)
         if [ "$build_system" = 'meson' ]; then
-          meson setup build -D qt6=true -D gtk=false
+          meson setup build -D gtk=false
         else
           export PATH="/usr/local/opt/qt@5/bin:$PATH"
           export PKG_CONFIG_PATH="/usr/local/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
           ./autogen.sh && ./configure --disable-gtk
+        fi
+        ;;
+
+      windows*)
+        if [ "$build_system" = 'meson' ]; then
+          meson setup build
+        else
+          ./autogen.sh && ./configure
         fi
         ;;
 

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,11 @@ thread_dep = dependency('threads', required: true)
 
 
 if get_option('qt')
-  if get_option('qt6')
+  if get_option('qt5')
+    qt = import('qt5')
+    qt_req = '>= 5.2'
+    qt_dep = dependency('qt5', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
+  else
     if meson.version().version_compare('>= 0.57')
       qt = import('qt6')
     else
@@ -30,10 +34,6 @@ if get_option('qt')
 
     qt_req = '>= 6.0'
     qt_dep = dependency('qt6', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
-  else
-    qt = import('qt5')
-    qt_req = '>= 5.2'
-    qt_dep = dependency('qt5', version: qt_req, required: true, modules: ['Core', 'Widgets', 'Gui'])
   endif
 endif
 
@@ -231,8 +231,8 @@ if meson.version().version_compare('>= 0.53')
 
   summary({
     'D-Bus support': get_option('dbus'),
-    'Qt 5 support': get_option('qt') and not get_option('qt6'),
-    'Qt 6 support': get_option('qt6'),
+    'Qt 5 support': get_option('qt5'),
+    'Qt 6 support': get_option('qt') and not get_option('qt5'),
     'GTK2 support': get_option('gtk') and not get_option('gtk3'),
     'GTK3 support': get_option('gtk3'),
     'Libarchive support': get_option('libarchive'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,8 +2,8 @@ option('dbus', type: 'boolean', value: true,
        description: 'Whether DBus support is enabled')
 option('qt', type: 'boolean', value: true,
        description: 'Whether Qt support is enabled')
-option('qt6', type: 'boolean', value: false,
-       description: 'Whether Qt 6 support is enabled')
+option('qt5', type: 'boolean', value: false,
+       description: 'Whether Qt 5 support is enabled')
 option('gtk', type: 'boolean', value: true,
        description: 'Whether GTK support is enabled')
 option('gtk3', type: 'boolean', value: false,


### PR DESCRIPTION
Qt 5 is no longer supported upstream and KDE has migrated as well.
Note that our Autotools build does not support Qt 6.

See also: https://doc.qt.io/qt-6/supported-platforms.html#supported-qt-versions