### PR TITLE
Use X11/XWayland by default

### DIFF
--- a/src/libaudgui/init.cc
+++ b/src/libaudgui/init.cc
@@ -344,6 +344,13 @@ EXPORT void audgui_init ()
     if (init_count ++)
         return;
 
+#if defined(GDK_WINDOWING_WAYLAND) && defined(GDK_WINDOWING_X11)
+    // Use X11/XWayland by default, but allow to overwrite it.
+    // Especially the Winamp interface is not usable yet on Wayland
+    // due to limitations regarding application-side window positioning.
+    g_setenv ("GDK_BACKEND", "x11", false);
+#endif
+
     static char app_name[] = "audacious";
     static char * app_args[] = {app_name, nullptr};
 

--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -120,6 +120,14 @@ EXPORT void init()
         Qt::HighDpiScaleFactorRoundingPolicy::Floor);
 #endif
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+    // Use X11/XWayland by default, but allow to overwrite it.
+    // Especially the Winamp interface is not usable yet on Wayland
+    // due to limitations regarding application-side window positioning.
+    if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+        qputenv("QT_QPA_PLATFORM", "xcb");
+#endif
+
     static char app_name[] = "audacious";
     static int dummy_argc = 1;
     static char * dummy_argv[] = {app_name, nullptr};


### PR DESCRIPTION
More and more distributions use Wayland by default now. Which brings new issues for Audacious, especially with the Winamp interface. Use X11/XWayland by default for now to avoid them.

See also:
- https://github.com/orgs/audacious-media-player/discussions/105
- https://github.com/orgs/audacious-media-player/discussions/1392
- https://github.com/orgs/audacious-media-player/discussions/1394

@madpilot78: Can you please verify that the `x11` GDK backend and `xcb` Qt platform can be used on FreeBSD? I'm not sure yet if we should apply this for Linux only.

@jlindgren90: Is this implemented properly? I have tested it successfully with a Ubuntu 24.04 VM.