### PR TITLE
Set LIB_PATCH in makefiles for correct SONAMEs. Closes: #1408

### DIFF
--- a/src/libaudcore/Makefile
+++ b/src/libaudcore/Makefile
@@ -1,6 +1,7 @@
 SHARED_LIB = ${LIB_PREFIX}audcore${LIB_SUFFIX}
 LIB_MAJOR = 5
 LIB_MINOR = 5
+LIB_PATCH = 0
 
 SRCS = adder.cc \
        archive_reader.cc \

--- a/src/libaudgui/Makefile
+++ b/src/libaudgui/Makefile
@@ -1,6 +1,7 @@
 SHARED_LIB = ${LIB_PREFIX}audgui${LIB_SUFFIX}
 LIB_MAJOR = 6
 LIB_MINOR = 0
+LIB_PATCH = 0
 
 SRCS = about.cc \
        confirm.cc \

--- a/src/libaudqt/Makefile
+++ b/src/libaudqt/Makefile
@@ -1,6 +1,7 @@
 SHARED_LIB = ${LIB_PREFIX}audqt${LIB_SUFFIX}
 LIB_MAJOR = 3
 LIB_MINOR = 0
+LIB_PATCH = 0
 
 SRCS = about-qt.cc \
        art-qt.cc \

--- a/src/libaudtag/Makefile
+++ b/src/libaudtag/Makefile
@@ -1,6 +1,7 @@
 SHARED_LIB = ${LIB_PREFIX}audtag${LIB_SUFFIX}
 LIB_MAJOR = 3
 LIB_MINOR = 0
+LIB_PATCH = 0
 
 SRCS = audtag.cc		\
        util.cc		\


### PR DESCRIPTION
Buildsys no longer hardcodes it to 0 and doesn't use a fallback value.

See also: https://fl.nil.im/buildsys/vinfo/56ccacdc62ad446c