### PR TITLE
mkrelease: Calculate checksum for tarballs. Closes: #1432

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,7 @@ win32/override/README.txt
 *.moc
 *.o
 *.patch
+*.sha256sum
 *.so
+*.tar.bz2
 *~

--- a/mkrelease.sh
+++ b/mkrelease.sh
@@ -25,3 +25,6 @@ rm -rf .github .gitignore aclocal.m4 autom4te.cache
 echo "Building $RELEASENAME.tar.bz2 ..."
 cd .. || exit 1
 tar cfj $RELEASENAME.tar.bz2 $RELEASENAME || exit 1
+
+echo "Calculating checksum ..."
+sha256sum $RELEASENAME.tar.bz2 > $RELEASENAME.sha256sum || exit 1


### PR DESCRIPTION
This allows users and packagers to verify them using
`sha256sum --check audacious-$version.sha256sum`