### PR TITLE
audqt: Parse font family names containing digits correctly

### DIFF
--- a/src/libaudqt/font-entry.cc
+++ b/src/libaudqt/font-entry.cc
@@ -20,6 +20,8 @@
 
 #include "libaudqt.h"
 
+#include <stdlib.h>
+
 #include <QAction>
 #include <QFontDialog>
 #include <QLineEdit>
@@ -72,11 +74,13 @@ EXPORT QFont qfont_from_string(const char * name)
         if (space)
         {
             const char * attr = space + 1;
-            int num = str_to_int(attr);
+
+            char * endptr;
+            long num = strtol(attr, &endptr, 10);
 
             attr_found = true;
 
-            if (num > 0)
+            if (num > 0 && *endptr == '\0')
                 size = num;
             else if (!strcmp(attr, "Light"))
                 weight = QFont::Light;


### PR DESCRIPTION
"PxPlus ToshibaSat 9x16 Bold 8" from the Oldschool PC Font Pack is such an example.
To parse the font family correctly, we need to check if all characters for the font size are digits.

Both `str_to_int()` and `atoi()` do not support this.
Use `strtol()` instead and check `endptr` accordingly.

Closes: #1483