### PR TITLE
Make UI appear on Qt::ApplicationActive for macOS

### DIFF
--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -28,6 +28,7 @@
 
 #include <libaudcore/audstrings.h>
 #include <libaudcore/i18n.h>
+#include <libaudcore/interface.h>
 #include <libaudcore/runtime.h>
 
 #include "libaudqt-internal.h"
@@ -181,10 +182,17 @@ EXPORT void init()
     // to use 9 pt in most places so let's try to do the same.
     QApplication::setFont(QApplication::font("QMenu"));
 #endif
-#ifdef Q_OS_MAC // Mac-specific font tweaks
+#ifdef Q_OS_MAC
+    // Mac-specific font tweaks
     QApplication::setFont(QApplication::font("QSmallFont"), "QDialog");
     QApplication::setFont(QApplication::font("QSmallFont"), "QTreeView");
     QApplication::setFont(QApplication::font("QTipLabel"), "QStatusBar");
+
+    // Handle MacOS dock activation (AppKit applicationShouldHandleReopen)
+    QObject::connect(qapp, &QApplication::applicationStateChanged, [](auto state) {
+        if (state == Qt::ApplicationState::ApplicationActive)
+            aud_ui_show(true);
+    });
 #endif
 }
 


### PR DESCRIPTION
See audacious-media-player/audacious-plugins#174

Sorry, forgot about skins since I don't typically use them. Since the signal handler is sufficiently decoupled via `aud_ui_show` anyway, I was thinking it would be cleaner to just hook this directly where the QApplication is instantiated along with the other platform specific code.
