### PR TITLE
audqt: Plug massive memory leaks in Jump-to-Song dialog

### DIFF
--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -207,6 +207,7 @@ EXPORT void cleanup()
     log_inspector_hide();
     plugin_prefs_hide();
     prefswin_hide();
+    songwin_hide();
 
     log_cleanup();
 


### PR DESCRIPTION
Opening the dialog and searching entries leaked memory every time.