### PR TITLE
audgui/audqt: Create new playlist when importing one. Closes: #1508

### DIFF
--- a/src/libaudgui/playlists.cc
+++ b/src/libaudgui/playlists.cc
@@ -63,21 +63,22 @@ static void finish_job (void * data)
 {
     ImportExportJob * job = (ImportExportJob *) data;
 
-    Playlist::GetMode mode = Playlist::Wait;
-    if (aud_get_bool ("metadata_on_play"))
-        mode = Playlist::NoWait;
-
-    if (job->list.exists ())
+    if (job->save)
     {
-        job->list.set_filename (job->filename);
-
-        if (job->save)
-            job->list.save_to_file (job->filename, mode);
-        else
+        if (job->list.exists ())
         {
-            job->list.remove_all_entries ();
-            job->list.insert_entry (0, job->filename, Tuple (), false);
+            auto mode = aud_get_bool ("metadata_on_play")
+             ? Playlist::NoWait : Playlist::Wait;
+
+            job->list.set_filename (job->filename);
+            job->list.save_to_file (job->filename, mode);
         }
+    }
+    else
+    {
+        auto list = Playlist::blank_playlist ();
+        list.set_filename (job->filename);
+        list.insert_entry (0, job->filename, Tuple (), false);
     }
 
     gtk_widget_destroy (job->selector);

--- a/src/libaudqt/fileopener.cc
+++ b/src/libaudqt/fileopener.cc
@@ -38,12 +38,14 @@ static aud::array<FileMode, QPointer<QFileDialog>> s_dialogs;
 static void import_playlist(Playlist playlist, const char * filename)
 {
     playlist.set_filename(filename);
-    playlist.remove_all_entries();
     playlist.insert_entry(0, filename, Tuple(), false);
 }
 
 static void export_playlist(Playlist playlist, const char * filename)
 {
+    if (!playlist.exists())
+        return;
+
     Playlist::GetMode mode = Playlist::Wait;
     if (aud_get_bool("metadata_on_play"))
         mode = Playlist::NoWait;
@@ -159,7 +161,10 @@ EXPORT void fileopener_show(FileMode mode)
                     break;
                 case FileMode::ImportPlaylist:
                     if (files.len() == 1)
-                        import_playlist(playlist, files[0].filename);
+                    {
+                        import_playlist(Playlist::blank_playlist(),
+                                        files[0].filename);
+                    }
                     break;
                 case FileMode::ExportPlaylist:
                     if (files.len() == 1)


### PR DESCRIPTION
This is more user-friendly since the playlist entries of the current playlist are not overwritten without confirmation.