### PR TITLE
desktop: add directories as supported mime types

### DIFF
--- a/audacious.desktop
+++ b/audacious.desktop
@@ -10,7 +10,7 @@ Exec=audacious %U
 TryExec=audacious
 StartupNotify=false
 Terminal=false
-MimeType=application/ogg;application/x-cue;application/x-ogg;application/xspf+xml;audio/aac;audio/flac;audio/midi;audio/mp3;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/prs.sid;audio/wav;audio/x-flac;audio/x-it;audio/x-mod;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-asx;audio/x-ms-wma;audio/x-musepack;audio/x-s3m;audio/x-scpls;audio/x-stm;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-xm;x-content/audio-cdda;
+MimeType=application/ogg;application/x-cue;application/x-ogg;application/xspf+xml;audio/aac;audio/flac;audio/midi;audio/mp3;audio/mp4;audio/mpeg;audio/mpegurl;audio/ogg;audio/prs.sid;audio/wav;audio/x-flac;audio/x-it;audio/x-mod;audio/x-mp3;audio/x-mpeg;audio/x-mpegurl;audio/x-ms-asx;audio/x-ms-wma;audio/x-musepack;audio/x-s3m;audio/x-scpls;audio/x-stm;audio/x-vorbis+ogg;audio/x-wav;audio/x-wavpack;audio/x-xm;x-content/audio-cdda;inode/directory;
 SingleMainWindow=true
 
 Comment[af]=Luister na musiek


### PR DESCRIPTION
Audacious can handle opening a whole directory (in which case in plays all media inside of it), but won't show up in the "Open With…" options in file managers (e.g.: nemo) because it doesn't explicitly declare support for this.

Add inode/directory to supported mime-types so that file managers show audacious in their "Open With…" menus.