### PR TITLE
audtag: Parse ID3 genre tag Blues correctly. Closes: #1643

### DIFF
--- a/contrib/audacious.appdata.xml
+++ b/contrib/audacious.appdata.xml
@@ -28,7 +28,7 @@
   </description>
   <url type="homepage">https://audacious-media-player.org</url>
   <url type="bugtracker">https://github.com/audacious-media-player/audacious/issues</url>
-  <url type="translate">https://transifex.com/audacious/audacious</url>
+  <url type="translate">https://app.transifex.com/audacious</url>
   <releases>
     <release date="2025-07-16" version="4.5"></release>
     <release date="2024-11-03" version="4.4.2"></release>

--- a/src/libaudtag/id3/id3-common.cc
+++ b/src/libaudtag/id3/id3-common.cc
@@ -19,6 +19,7 @@
 
 #include "id3-common.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -139,12 +140,7 @@ void id3_decode_genre (Tuple & tuple, const char * data, int size)
     if (! text)
         return;
 
-    if (text[0] == '(')
-        numericgenre = atoi (text + 1);
-    else
-        numericgenre = atoi (text);
-
-    if (numericgenre > 0)
+    if (sscanf (text, "(%d)", & numericgenre) == 1 || sscanf (text, "%d", & numericgenre) == 1)
         tuple.set_str (Tuple::Genre, convert_numericgenre_to_text (numericgenre));
     else
         tuple.set_str (Tuple::Genre, text);


### PR DESCRIPTION
Blues is represented as "(0)" if the tag is saved numerically.
With atoi() we can't distinguish if we got a valid numeric genre
because it returns also 0 when parsing strings like "Blues".
Use sscanf() instead which is more reliable here.

See also: https://en.wikipedia.org/wiki/List_of_ID3v1_genres