### PR TITLE
Restore starting playback from position in playlist

### DIFF
--- a/src/libaudcore/config.cc
+++ b/src/libaudcore/config.cc
@@ -39,6 +39,7 @@ static const char * const core_defaults[] = {
     "always_resume_paused", "TRUE",
     "clear_playlist", "TRUE",
     "open_to_temporary", "TRUE",
+    "resume_from_start", "TRUE",
     "recurse_folders", "TRUE",
     "resume_playback_on_startup", "TRUE",
     "show_interface", "TRUE",

--- a/src/libaudcore/drct.cc
+++ b/src/libaudcore/drct.cc
@@ -46,7 +46,8 @@ EXPORT void aud_drct_play()
     else
     {
         auto playlist = Playlist::active_playlist();
-        playlist.set_position(playlist.get_position());
+	if (aud_get_bool("resume_from_start"))
+            playlist.set_position(playlist.get_position());
         playlist.start_playback();
     }
 }

--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -326,6 +326,8 @@ static const PreferencesWidget playlist_page_widgets[] = {
         WidgetBool (0, "clear_playlist")),
     WidgetCheck (N_("Open files in a temporary playlist"),
         WidgetBool (0, "open_to_temporary")),
+    WidgetCheck (N_("Resume playback from start of song"),
+        WidgetBool (0, "resume_from_start")),
     WidgetLabel (N_("<b>Song Display</b>")),
     WidgetCheck (N_("Show song numbers"),
         WidgetBool (0, "show_numbers_in_pl", send_title_change)),

--- a/src/libaudqt/prefs-window-qt.cc
+++ b/src/libaudqt/prefs-window-qt.cc
@@ -367,6 +367,8 @@ static const PreferencesWidget playlist_page_widgets[] = {
                 WidgetBool(0, "clear_playlist")),
     WidgetCheck(N_("Open files in a temporary playlist"),
                 WidgetBool(0, "open_to_temporary")),
+    WidgetCheck (N_("Resume playback from start of song"),
+		 WidgetBool (0, "resume_from_start")),
     WidgetLabel(N_("<b>Song Display</b>")),
     WidgetCheck(N_("Show song numbers"),
                 WidgetBool(0, "show_numbers_in_pl", send_title_change)),


### PR DESCRIPTION
Audacious stores the current playback position within a song in the playlist. That position is kept when the playlist is loaded and the playlist implementation contains code which implements restarting playback from that stored position. Unfortunately playback always starts from the start of the song even if a playback position was stored in the playlist.

This commit restores the ability of Audacious to restart playback from a position within the song.

Digging into the Git history, it looks like when
0c38a8d7b779 ("Playlist API revamp.") was committed, playback restart from within a song was broken. The above mentioned commit changed the body of `aud_drct_play()` from:

```
aud_playlist_set_position (playlist, aud_playlist_get_position (playlist));
aud_playlist_play (playlist);
```

to:

```
playlist.set_position (playlist.get_position ());
playlist.start_playback ();
```

which looks semantically identical, but while
`aud_playlist_set_position(playlist,
aud_playlist_get_position(playlist))` is documented to be a no-op, `playlist.set_position(playlist.get_position())` is documented to reset the playback position to the start of the song. That is, to preserve the semantics, the get+set-position should have been removed and only `playlist.start_playback()` should have remained (as it is documented to start playback from the position in the playlist)

As the behavior for the last eight years has been to always start playback from the start of the song, this patch adds a configuration option which enables the current behavior ("Resume playback from start of song") and is enabled by default. If it is disabled, playback once again restarts from where it left off in the song.