### PR TITLE
audtool: Support exporting playlists via CLI. Closes: #1659

### DIFF
--- a/src/audacious/dbus-server.cc
+++ b/src/audacious/dbus-server.cc
@@ -464,6 +464,18 @@ static gboolean do_playlist_add(Obj * obj, Invoc * invoc, const char * list)
     return true;
 }
 
+static gboolean do_playlist_save(Obj * obj, Invoc * invoc, const char * url)
+{
+    bool success;
+    ENTER_MAIN_THREAD(url, &success)
+    auto mode =
+        aud_get_bool("metadata_on_play") ? Playlist::NoWait : Playlist::Wait;
+    success = CURRENT.save_to_file(url, mode);
+    LEAVE_MAIN_THREAD()
+    FINISH2(playlist_save, success);
+    return true;
+}
+
 static gboolean do_playlist_enqueue_to_temp(Obj * obj, Invoc * invoc,
                                             const char * url)
 {
@@ -1045,6 +1057,7 @@ static const struct
     {"handle-play-pause", (GCallback)do_play_pause},
     {"handle-playing", (GCallback)do_playing},
     {"handle-playlist-add", (GCallback)do_playlist_add},
+    {"handle-playlist-save", (GCallback)do_playlist_save},
     {"handle-playlist-enqueue-to-temp", (GCallback)do_playlist_enqueue_to_temp},
     {"handle-playlist-ins-url-string", (GCallback)do_playlist_ins_url_string},
     {"handle-playqueue-add", (GCallback)do_playqueue_add},

--- a/src/audtool/audtool.h
+++ b/src/audtool/audtool.h
@@ -78,6 +78,7 @@ void playlist_display (int, char * *);
 void playlist_position (int, char * *);
 void playlist_jump (int, char * *);
 void playlist_add_url_string (int, char * *);
+void playlist_save (int, char * *);
 void playlist_delete (int, char * *);
 void playlist_clear (int, char * *);
 void playlist_repeat_status (int, char * *);

--- a/src/audtool/handlers_playlist.c
+++ b/src/audtool/handlers_playlist.c
@@ -141,6 +141,36 @@ void playlist_add_url_string (int argc, char * * argv)
     g_free (uri);
 }
 
+void playlist_save (int argc, char * * argv)
+{
+    char * uri;
+    gboolean success = FALSE;
+
+    if (argc < 2)
+    {
+        audtool_whine_args (argv[0], "<url>");
+        exit (1);
+    }
+
+    uri = construct_uri (argv[1]);
+
+    if (! uri)
+        exit (1);
+
+    obj_audacious_call_playlist_save_sync (dbus_proxy, uri, & success, NULL, NULL);
+
+    if (! success)
+    {
+        audtool_report ("Error saving %s:\nMake sure to use a supported "
+                        "file extension and that the respective playlist "
+                        "plugin is enabled.", uri);
+        g_free (uri);
+        exit (1);
+    }
+    else
+        g_free (uri);
+}
+
 void playlist_delete (int argc, char * * argv)
 {
     int pos = check_args_playlist_pos (argc, argv);

--- a/src/audtool/main.c
+++ b/src/audtool/main.c
@@ -92,6 +92,7 @@ const struct commandhandler handlers[] =
     {"playlist-shuffle-toggle", playlist_shuffle_toggle, "toggle playlist shuffle", 0},
     {"playlist-stop-after-status", playlist_stop_after_status, "query if stopping after current song", 0},
     {"playlist-stop-after-toggle", playlist_stop_after_toggle, "toggle if stopping after current song", 0},
+    {"playlist-save", playlist_save, "save playlist to given file path", 1},
 
     {"<sep>", NULL, "More playlist commands", 0},
     {"number-of-playlists", number_of_playlists, "print number of playlists", 0},

--- a/src/dbus/aud-dbus.xml
+++ b/src/dbus/aud-dbus.xml
@@ -366,6 +366,12 @@
             <arg type="u" direction="in" name="pos"/>
         </method>
 
+        <!-- Save the playlist to given file path -->
+        <method name="PlaylistSave">
+            <arg type="s" direction="in" name="url"/>
+            <arg type="b" direction="out" name="success"/>
+        </method>
+
         <!-- Clear the playlist -->
         <method name="Clear" />
 


### PR DESCRIPTION
The format is determined by the file extension, similar to when exporting playlists from the GUI.

Example usage:
- audtool playlist-save file.m3u
- audtool playlist-save /tmp/file.audpl
- audtool playlist-save file:///tmp/file.asx
- audtool --select-displayed playlist-save file.pls