### PR TITLE
Enable XWayland only for skinned UI (part 1)

### DIFF
--- a/config.h.meson
+++ b/config.h.meson
@@ -25,5 +25,6 @@
 #mesondefine USE_GTK
 #mesondefine USE_GTK3
 #mesondefine USE_LIBARCHIVE
+#mesondefine USE_XWAYLAND
 
 #mesondefine GLIB_VERSION_MIN_REQUIRED

--- a/meson.build
+++ b/meson.build
@@ -175,6 +175,9 @@ endif
 
 if get_option('qt')
   conf.set10('USE_QT', true)
+  if qt_dep.version().version_compare('<= 6.7')
+    conf.set10('USE_XWAYLAND', true)
+  endif
 endif
 
 

--- a/src/libaudcore/config.cc
+++ b/src/libaudcore/config.cc
@@ -43,6 +43,11 @@ static const char * const core_defaults[] = {
     "resume_playback_on_startup", "TRUE",
     "show_interface", "TRUE",
     "use_qt", "TRUE",
+#ifdef USE_XWAYLAND
+    "use_xwayland", "TRUE",
+#else
+    "use_xwayland", "FALSE",
+#endif
 
     /* equalizer */
     "eqpreset_default_file", "",

--- a/src/libaudgui/init.cc
+++ b/src/libaudgui/init.cc
@@ -343,15 +343,12 @@ EXPORT void audgui_init ()
         return;
 
 #if defined(GDK_WINDOWING_WAYLAND) && defined(GDK_WINDOWING_X11)
-    // Use X11/XWayland by default, but allow to overwrite it.
-    // Especially the Winamp interface is not usable yet on Wayland
-    // due to limitations regarding application-side window positioning.
-    auto backend = g_getenv ("GDK_BACKEND");
-    if (! backend && g_getenv ("DISPLAY"))
-        g_setenv ("GDK_BACKEND", "x11", false);
-    else if (g_strcmp0 (backend, "x11"))
-        AUDWARN ("X11/XWayland was not detected. This is unsupported, "
-                 "please do not report bugs.\n");
+    // The Winamp interface is not usable yet on Wayland (and perhaps
+    // may never be) due to protocol limitations regarding application-
+    // side window positioning. Force XWayland if needed and available.
+    PluginHandle * skins = aud_plugin_lookup_basename ("skins");
+    if (skins && aud_plugin_get_enabled (skins) && g_getenv ("DISPLAY"))
+        g_setenv ("GDK_BACKEND", "x11", true);
 #endif
 
     static char app_name[] = "audacious";

--- a/src/libaudgui/init.cc
+++ b/src/libaudgui/init.cc
@@ -18,12 +18,10 @@
  */
 
 #include <assert.h>
-#include <stdlib.h>
 
 #include <libaudcore/audstrings.h>
 #include <libaudcore/hook.h>
 #include <libaudcore/playlist.h>
-#include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 
 #include "internal.h"
@@ -343,11 +341,8 @@ EXPORT void audgui_init ()
         return;
 
 #if defined(GDK_WINDOWING_WAYLAND) && defined(GDK_WINDOWING_X11)
-    // The Winamp interface is not usable yet on Wayland (and perhaps
-    // may never be) due to protocol limitations regarding application-
-    // side window positioning. Force XWayland if needed and available.
-    PluginHandle * skins = aud_plugin_lookup_basename ("skins");
-    if (skins && aud_plugin_get_enabled (skins) && g_getenv ("DISPLAY"))
+    // Force Xwayland if requested and potentially available
+    if (aud_get_bool ("use_xwayland") && g_getenv ("DISPLAY"))
         g_setenv ("GDK_BACKEND", "x11", true);
 #endif
 

--- a/src/libaudgui/prefs-window.cc
+++ b/src/libaudgui/prefs-window.cc
@@ -367,6 +367,10 @@ static const PreferencesWidget song_info_page_widgets[] = {
 
 static const PreferencesWidget advanced_page_widgets[] = {
     WidgetLabel (N_("<b>Compatibility</b>")),
+#if defined(GDK_WINDOWING_WAYLAND) && defined(GDK_WINDOWING_X11)
+    WidgetCheck (N_("Use Xwayland (requires a restart to take effect)"),
+        WidgetBool (0, "use_xwayland")),
+#endif
     WidgetCheck (N_("Interpret \\ (backward slash) as a folder delimiter"),
         WidgetBool (0, "convert_backslash")),
     WidgetTable ({{chardet_elements}}),

--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -29,6 +29,7 @@
 #include <libaudcore/audstrings.h>
 #include <libaudcore/i18n.h>
 #include <libaudcore/interface.h>
+#include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 
 #include "libaudqt-internal.h"
@@ -135,15 +136,12 @@ EXPORT void init()
 #endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    // Use X11/XWayland by default, but allow to overwrite it.
-    // Especially the Winamp interface is not usable yet on Wayland
-    // due to limitations regarding application-side window positioning.
-    auto platform = qgetenv("QT_QPA_PLATFORM");
-    if (platform.isEmpty() && qEnvironmentVariableIsSet("DISPLAY"))
+    // The Winamp interface is not usable yet on Wayland (and perhaps
+    // may never be) due to protocol limitations regarding application-
+    // side window positioning. Force XWayland if needed and available.
+    PluginHandle * skins = aud_plugin_lookup_basename("skins-qt");
+    if (skins && aud_plugin_get_enabled(skins) && !qgetenv("DISPLAY").isEmpty())
         qputenv("QT_QPA_PLATFORM", "xcb");
-    else if (platform != "xcb")
-        AUDWARN("X11/XWayland was not detected. This is unsupported, "
-                "please do not report bugs.\n");
 #endif
 
     static char app_name[] = "audacious";

--- a/src/libaudqt/audqt.cc
+++ b/src/libaudqt/audqt.cc
@@ -29,7 +29,6 @@
 #include <libaudcore/audstrings.h>
 #include <libaudcore/i18n.h>
 #include <libaudcore/interface.h>
-#include <libaudcore/plugins.h>
 #include <libaudcore/runtime.h>
 
 #include "libaudqt-internal.h"
@@ -136,11 +135,8 @@ EXPORT void init()
 #endif
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    // The Winamp interface is not usable yet on Wayland (and perhaps
-    // may never be) due to protocol limitations regarding application-
-    // side window positioning. Force XWayland if needed and available.
-    PluginHandle * skins = aud_plugin_lookup_basename("skins-qt");
-    if (skins && aud_plugin_get_enabled(skins) && !qgetenv("DISPLAY").isEmpty())
+    // Force Xwayland if requested and potentially available
+    if (aud_get_bool("use_xwayland") && qEnvironmentVariableIsSet("DISPLAY"))
         qputenv("QT_QPA_PLATFORM", "xcb");
 #endif
 

--- a/src/libaudqt/prefs-window-qt.cc
+++ b/src/libaudqt/prefs-window-qt.cc
@@ -399,6 +399,10 @@ static const PreferencesWidget song_info_page_widgets[] = {
 
 static const PreferencesWidget advanced_page_widgets[] = {
     WidgetLabel(N_("<b>Compatibility</b>")),
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+    WidgetCheck(N_("Use Xwayland (requires a restart to take effect)"),
+                WidgetBool(0, "use_xwayland")),
+#endif
     WidgetCheck(N_("Interpret \\ (backward slash) as a folder delimiter"),
                 WidgetBool(0, "convert_backslash")),
     WidgetTable({{chardet_elements}}),


### PR DESCRIPTION
The newer (GTK and Qt) UIs are mostly usable with native Wayland. Undocked plugins are still problematic, since positions are not saved/restored, but (1) keeping them docked is a workaround and (2) maybe it's time to let the problem be more visible so it gets solved?

Needs accompanying change on plugins side.