### PR TITLE
audcore: don't include linux/stat.h

### DIFF
--- a/src/libaudcore/vfs_local.cc
+++ b/src/libaudcore/vfs_local.cc
@@ -446,7 +446,6 @@ bool LocalTransport::get_file_timestamps(const char * filename, int64_t * mtime,
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <linux/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 


### PR DESCRIPTION
on glibc, this is redundant (`sys/stat.h` includes `bits/statx.h` includes `linux/stat.h`). on musl, it results in an error that `struct statx` and `struct statx_timestamp` are being redefined. `sys/stat.h` is the proper interface to use when using `statx` on linux.

tested this by building for `x86_64`, `i686`, `aarch64`, `armv7l`, and `armv6l` for both `glibc` and `musl` on Void Linux.