### PR TITLE
Bump .so and plugin ABI versions. Closes: #1819

### DIFF
--- a/src/libaudcore/plugin.h
+++ b/src/libaudcore/plugin.h
@@ -47,8 +47,8 @@ struct PluginPreferences;
  * the API tables), increment _AUD_PLUGIN_VERSION *and* set
  * _AUD_PLUGIN_VERSION_MIN to the same value. */
 
-#define _AUD_PLUGIN_VERSION_MIN 48 /* 3.8-devel */
-#define _AUD_PLUGIN_VERSION 48     /* 3.8-devel */
+#define _AUD_PLUGIN_VERSION_MIN 49 /* 4.6.1 */
+#define _AUD_PLUGIN_VERSION 49     /* 4.6.1 */
 
 /* Default priority. */
 #define _AUD_PLUGIN_DEFAULT_PRIO 5

--- a/src/libaudgui/meson.build
+++ b/src/libaudgui/meson.build
@@ -55,7 +55,7 @@ libaudgui_lib = library('audgui',
   include_directories: [src_inc],
   dependencies: [gtk_dep, intl_dep],
   link_with: [libaudcore_lib],
-  soversion: '6',
-  version: '6.0.0',
+  soversion: '7',
+  version: '7.0.0',
   install: true
 )

--- a/src/libaudtag/meson.build
+++ b/src/libaudtag/meson.build
@@ -21,7 +21,7 @@ libaudtag_lib = library('audtag',
   include_directories: src_inc,
   dependencies: [glib_dep],
   link_with: libaudcore_lib,
-  version: '3.0.0',
-  soversion: 3,
+  version: '4.0.0',
+  soversion: 4,
   install: true
 )


### PR DESCRIPTION
Commit 0b4a5b2ae1522adfe85f for libaudcore has (intentionally) introduced an ABI break. The .so version for libaud{core/qt} was adjusted accordingly for Audacious 4.6. But since libaud{gui/tag} are linked with libaudcore and plugins may be linked with them, we need to increase their versions too.

See also: Pull Request #1693