### PR TITLE
audtag: Accept embedded lyrics in more cases. Closes: #1818

### DIFF
--- a/src/libaudtag/id3/id3-common.cc
+++ b/src/libaudtag/id3/id3-common.cc
@@ -162,8 +162,20 @@ void id3_associate_memo (Tuple & tuple, Tuple::Field field, const char * data, i
      Tuple::field_get_name (field), lang, (const char *) type,
      (const char *) value);
 
-    if (type && ! type[0] && value) /* blank type = actual comment */
-        tuple.set_str (field, value);
+    if (! value)
+        return;
+
+    switch (field)
+    {
+        case Tuple::Field::Lyrics: /* type may be set to e.g. "LYRICS" */
+            tuple.set_str (field, value);
+            break;
+
+        default:
+            if (type && ! type[0]) /* blank type = actual comment */
+                tuple.set_str (field, value);
+            break;
+    }
 }
 
 static bool decode_rva_block (const char * * _data, int * _size,


### PR DESCRIPTION
Some ID3v2 headers contain lyrics with the type "LYRICS".
They were read successfully before but then disregarded.
Add a special case for the lyrics field to prevent that.

DEBUG ../src/libaudtag/id3/id3-common.cc:161 [id3_associate_memo]:
Field lyrics: lang = XXX, type = LYRICS, value = ...